### PR TITLE
Add tag_manager gubbins to publish layout

### DIFF
--- a/app/views/layouts/publish_data.html.erb
+++ b/app/views/layouts/publish_data.html.erb
@@ -1,6 +1,7 @@
 <!doctype html>
 <html lang="en">
   <head>
+    <%= tag_manager_js -%>
     <meta charset="utf-8">
 
     <title><%= page.title %></title>
@@ -18,6 +19,7 @@
   </head>
 
   <body>
+    <%= tag_manager_nojs -%>
     <a href="#main" class="skip-link">Skip to main content</a>
 
     <header class="header<% unless page.display_header_border %> header--without-border<% end %>">


### PR DESCRIPTION
The tag manager snippets were not added to the layout for publish
and so this now includes them.