### PR TITLE
Contrains the services count to only those with data

### DIFF
--- a/app/models/delivery_organisation.rb
+++ b/app/models/delivery_organisation.rb
@@ -9,11 +9,15 @@ class DeliveryOrganisation < ApplicationRecord
   validates_presence_of :name
   validates_presence_of :website
 
+  def self.with_services
+    self.joins(:metrics).where(monthly_service_metrics: { published: true }).distinct
+  end
+
   def to_param
     natural_key
   end
 
   def services_count
-    services.count
+    services.with_published_metrics.count
   end
 end

--- a/app/models/department.rb
+++ b/app/models/department.rb
@@ -8,15 +8,19 @@ class Department < ApplicationRecord
   validates_presence_of :name, strict: true
   validates_presence_of :website, strict: true
 
+  def self.with_delivery_organisations
+    self.joins(:services).distinct
+  end
+
   def to_param
     natural_key
   end
 
   def delivery_organisations_count
-    delivery_organisations.count
+    delivery_organisations.with_services.count
   end
 
   def services_count
-    services.count
+    services.with_published_metrics.count
   end
 end

--- a/app/models/government.rb
+++ b/app/models/government.rb
@@ -4,16 +4,15 @@ class Government
   end
 
   def departments
-    orgs = DeliveryOrganisation.joins(:services).distinct.pluck(:department_id)
-    Department.find(orgs)
+    Department.with_delivery_organisations
   end
 
   def delivery_organisations
-    DeliveryOrganisation.joins(:services).distinct.all
+    DeliveryOrganisation.with_services
   end
 
   def services
-    Service.all
+    Service.with_published_metrics
   end
 
   def metrics
@@ -21,15 +20,14 @@ class Government
   end
 
   def departments_count
-    orgs = DeliveryOrganisation.joins(:services).distinct.pluck(:department_id)
-    Department.find(orgs).count
+    Department.with_delivery_organisations.count
   end
 
   def delivery_organisations_count
-    DeliveryOrganisation.joins(:services).distinct.count
+    DeliveryOrganisation.with_services.count
   end
 
   def services_count
-    Service.count
+    Service.with_published_metrics.count
   end
 end

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -12,6 +12,10 @@ class Service < ApplicationRecord
     self.publish_token ||= SecureRandom.hex(64)
   end
 
+  def self.with_published_metrics
+    self.joins(:metrics).where(monthly_service_metrics: { published: true }).distinct
+  end
+
   def to_param
     natural_key
   end

--- a/spec/models/government_spec.rb
+++ b/spec/models/government_spec.rb
@@ -28,19 +28,33 @@ RSpec.describe Government, type: :model do
       do1 = FactoryGirl.create(:delivery_organisation, name: "do test 1", department: d1)
       do2 = FactoryGirl.create(:delivery_organisation, name: "do test 2", department: d1)
 
-      FactoryGirl.create(:service, name: "service test 1", delivery_organisation: do1)
-      FactoryGirl.create(:service, name: "service test 2", delivery_organisation: do2)
+      s1 = FactoryGirl.create(:service, name: "service test 1", delivery_organisation: do1)
+      s2 = FactoryGirl.create(:service, name: "service test 2", delivery_organisation: do2)
 
+      FactoryGirl.create(:monthly_service_metrics, month: YearMonth.new(2017, 8), service: s1, published: true)
+      FactoryGirl.create(:monthly_service_metrics, month: YearMonth.new(2017, 8), service: s2, published: true)
 
       expect(government.delivery_organisations_count).to eq(2)
     end
   end
 
   describe '#services_count' do
-    it 'returns the total number of services' do
-      FactoryGirl.create_list(:service, 1)
+    it 'returns the total number of services who have published data correctly' do
+      s = FactoryGirl.create(:service)
+      FactoryGirl.create(:monthly_service_metrics, month: YearMonth.new(2017, 8), service: s, published: true)
 
       expect(government.services_count).to eq(1)
+    end
+    it 'returns the total number of services who have data, but not published, correctly' do
+      s = FactoryGirl.create(:service)
+      FactoryGirl.create(:monthly_service_metrics, month: YearMonth.new(2017, 8), service: s)
+
+      expect(government.services_count).to eq(0)
+    end
+    it 'returns the total number of services who have no data correctly' do
+      FactoryGirl.create(:service)
+
+      expect(government.services_count).to eq(0)
     end
   end
 end


### PR DESCRIPTION
Makes sure that we only show/count 

* delivery_organisations that have services
* services that have published data
