### PR TITLE
Compress responses in production

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -1,5 +1,6 @@
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
+  config.middleware.insert_before(Rack::Sendfile, Rack::Deflater)
 
   # Code is not reloaded between requests.
   config.cache_classes = true


### PR DESCRIPTION
Adds the deflater middleware, but advised to add before SendFile to ensure everything is compressed.