### PR TITLE
Show services in admin with missing context

### DIFF
--- a/app/admin/service.rb
+++ b/app/admin/service.rb
@@ -11,7 +11,7 @@ ActiveAdmin.register Service do
     column :delivery_organisation
     column :department
     column "Missing context" do |s|
-      status_tag("Missing", class: "error") if [s.purpose, s.how_it_works, s.typical_users, s.start_page_url].include?('')
+      status_tag("Missing", class: "error") if [s.purpose, s.how_it_works, s.typical_users, s.start_page_url].any?(&:blank?)
     end
     actions
   end

--- a/app/admin/service.rb
+++ b/app/admin/service.rb
@@ -10,8 +10,8 @@ ActiveAdmin.register Service do
     column :name
     column :delivery_organisation
     column :department
-    column "Owner" do |service|
-      service.owner.email if service.owner
+    column "Missing context" do |s|
+      status_tag("Missing", class: "error") if [s.purpose, s.how_it_works, s.typical_users, s.start_page_url].include?('')
     end
     actions
   end


### PR DESCRIPTION
For each service at /admin/services we show whether it has
missing context, which means that any of the following are ''

* Purpose
* How it works
* Typical users
* Start page URL