### PR TITLE
Adds skeleton pages for department and delivery org details

### DIFF
--- a/app/controllers/view_data/delivery_organisations_controller.rb
+++ b/app/controllers/view_data/delivery_organisations_controller.rb
@@ -1,0 +1,20 @@
+module ViewData
+  class DeliveryOrganisationsController < ViewDataController
+    def show
+      @delivery_organisation = DeliveryOrganisation.where(natural_key: params[:id]).first!
+
+      @metrics = MetricsPresenter.new(@delivery_organisation, group_by: Metrics::GroupBy::DeliveryOrganisation)
+
+      page.title = @delivery_organisation.name
+
+      page.breadcrumbs << Page::Crumb.new('UK Government', view_data_government_metrics_path)
+      page.breadcrumbs << Page::Crumb.new(@delivery_organisation.department.name, view_data_department_path(id: @delivery_organisation.department))
+      page.breadcrumbs << Page::Crumb.new(@delivery_organisation.name)
+
+      respond_to do |format|
+        format.html
+        format.csv { render csv: MetricsCSVExporter.new(@metrics.published_monthly_service_metrics) }
+      end
+    end
+  end
+end

--- a/app/controllers/view_data/departments_controller.rb
+++ b/app/controllers/view_data/departments_controller.rb
@@ -1,0 +1,19 @@
+module ViewData
+  class DepartmentsController < ViewDataController
+    def show
+      @department = Department.where(natural_key: params[:id]).first!
+
+      @metrics = MetricsPresenter.new(@department, group_by: Metrics::GroupBy::Department)
+
+      page.title = @department.name
+
+      page.breadcrumbs << Page::Crumb.new('UK Government', view_data_government_metrics_path)
+      page.breadcrumbs << Page::Crumb.new(@department.name)
+
+      respond_to do |format|
+        format.html
+        format.csv { render csv: MetricsCSVExporter.new(@metrics.published_monthly_service_metrics) }
+      end
+    end
+  end
+end

--- a/app/views/view_data/delivery_organisations/show.html.erb
+++ b/app/views/view_data/delivery_organisations/show.html.erb
@@ -1,0 +1,59 @@
+<main id="content" role="main">
+
+  <%= breadcrumbs %>
+
+  <div class="grid-row">
+    <div class="column-two-thirds">
+      <h1 class="heading-xlarge small-top-margin">
+        <span class="prefix">Detailed data for</span>
+        <%= @delivery_organisation.name %>
+      </h1>
+    </div>
+
+    <aside class="column-one-third download">
+      <div class="notice">
+        <i class="icon icon-file-download">
+          <span class="visuallyhidden">Download file</span>
+        </i>
+        <strong class="xbold-small"><%= link_to 'Download data for this page (CSV)', url_for(request.params.merge(format: :csv)) %></strong>
+      </div>
+    </aside>
+  </div>
+
+  <div class="grid-row">
+
+    <div class="column-two-thirds department-context">
+
+      <h1 class="heading-medium">Data about this delivery organisation</h1>
+
+      <p class="lede">
+        Showing data for the year from  <%= time_tag @metrics.time_period.starts_on, @metrics.time_period.starts_on.to_formatted_s(:abbreviated_day_month_year) %> to <%= time_tag @metrics.time_period.ends_on, @metrics.time_period.ends_on.to_formatted_s(:abbreviated_day_month_year) %>
+      </p>
+
+      <p class="lede">
+        Data is aggregated from <a href="<%= view_data_delivery_organisation_metrics_path delivery_organisation_id: @delivery_organisation.natural_key,group_by: Metrics::GroupBy::Service %>"><%= pluralize(@delivery_organisation.services_count, 'service')%></a></a>
+      </p>
+
+    </div>
+  </div>
+
+  <hr/>
+
+  <div class="grid-row">
+    <div class="column-full">
+      <h1 class="heading-medium">Delivery organisation data</h1>
+
+      <div class='m-metric-group'>
+        <div>
+          <div class='completeness service-context-completeness'>
+            <%= @metrics.metric_groups.last.completeness %> of data points complete
+          </div>
+
+          <div class="m-metrics">
+            <%= render @metrics.metric_groups.last.metrics, metric_group: @metrics.metric_groups.last%>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</main>

--- a/app/views/view_data/departments/show.html.erb
+++ b/app/views/view_data/departments/show.html.erb
@@ -1,0 +1,55 @@
+<main id="content" role="main">
+
+  <%= breadcrumbs %>
+
+  <div class="grid-row">
+    <div class="column-two-thirds">
+      <h1 class="heading-xlarge small-top-margin">
+        <span class="prefix">Detailed data for</span>
+        <%= @department.name %>
+      </h1>
+    </div>
+
+    <aside class="column-one-third download">
+      <div class="notice">
+        <i class="icon icon-file-download">
+          <span class="visuallyhidden">Download file</span>
+        </i>
+        <strong class="xbold-small"><%= link_to 'Download data for this page (CSV)', url_for(request.params.merge(format: :csv)) %></strong>
+      </div>
+    </aside>
+  </div>
+
+  <div class="grid-row">
+    <div class="column-two-thirds department-context">
+      <h1 class="heading-medium">Data about this organisation</h1>
+      <p class="lede">
+        Showing data for the year from  <%= time_tag @metrics.time_period.starts_on, @metrics.time_period.starts_on.to_formatted_s(:abbreviated_day_month_year) %> to <%= time_tag @metrics.time_period.ends_on, @metrics.time_period.ends_on.to_formatted_s(:abbreviated_day_month_year) %>
+      </p>
+
+      <p class="lede">
+        Data is aggregated from <a href="<%= view_data_department_metrics_path department_id: @department.natural_key,group_by: Metrics::GroupBy::Service %>"><%= pluralize(@department.services_count, 'service')%></a> in <a href="<%= view_data_department_metrics_path department_id: @department.natural_key,group_by: Metrics::GroupBy::DeliveryOrganisation %>"><%= pluralize(@department.delivery_organisations_count, 'delivery organisation')%></a>
+      </p>
+    </div>
+  </div>
+
+  <hr/>
+
+  <div class="grid-row">
+    <div class="column-full">
+      <h1 class="heading-medium">Department data</h1>
+
+      <div class='m-metric-group'>
+        <div>
+          <div class='completeness service-context-completeness'>
+            <%= @metrics.metric_groups.last.completeness %> of data points complete
+          </div>
+
+          <div class="m-metrics">
+            <%= render @metrics.metric_groups.last.metrics, metric_group: @metrics.metric_groups.last%>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+</main>

--- a/app/views/view_data/services/show.html.erb
+++ b/app/views/view_data/services/show.html.erb
@@ -20,11 +20,14 @@
     </div>
 
     <aside class="column-one-third download">
-      <i class="icon icon-file-download">
-        <span class="visuallyhidden">Download file</span>
-      </i>
-      <strong class="xbold-small"><%= link_to 'Download data for this page (CSV)', url_for(request.params.merge(format: :csv)) %></strong>
+      <div class="notice">
+        <i class="icon icon-file-download">
+          <span class="visuallyhidden">Download file</span>
+        </i>
+        <strong class="xbold-small"><%= link_to 'Download data for this page (CSV)', url_for(request.params.merge(format: :csv)) %></strong>
+      </div>
     </aside>
+
   </header>
 
   </div>

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -1,38 +1,19 @@
 {
   "ignored_warnings": [
     {
-      "warning_type": "Cross-Site Scripting",
-      "warning_code": 2,
-      "fingerprint": "391df96ef67e8178ebf2a1e2a4b714e65370f0f9a12dab5792bab8f5498b5ba8",
-      "check_name": "CrossSiteScripting",
-      "message": "Unescaped parameter value",
-      "file": "app/views/view_data/services/show.html.erb",
-      "line": 39,
-      "link": "http://brakemanscanner.org/docs/warning_types/cross_site_scripting",
-      "code": "\"service\".where(:natural_key => params[:id]).first!.purpose",
-      "render_path": [{"type":"controller","class":"ViewData::ServicesController","method":"show","line":18,"file":"app/controllers/view_data/services_controller.rb"}],
+      "warning_type": "Dynamic Render Path",
+      "warning_code": 15,
+      "fingerprint": "3edea751b1a949810f48aa2ab91497cc8d75cd0c072f1ac8276c7e4116a1e426",
+      "check_name": "Render",
+      "message": "Render path contains parameter value",
+      "file": "app/views/view_data/delivery_organisations/show.html.erb",
+      "line": 53,
+      "link": "http://brakemanscanner.org/docs/warning_types/dynamic_render_path/",
+      "code": "render(action => MetricsPresenter.new(\"delivery_organisation\".where(:natural_key => params[:id]).first!, :group_by => \"delivery_organisation\").metric_groups.last.metrics, { :metric_group => MetricsPresenter.new(\"delivery_organisation\".where(:natural_key => params[:id]).first!, :group_by => \"delivery_organisation\").metric_groups.last })",
+      "render_path": [{"type":"controller","class":"ViewData::DeliveryOrganisationsController","method":"show","line":15,"file":"app/controllers/view_data/delivery_organisations_controller.rb"}],
       "location": {
         "type": "template",
-        "template": "view_data/services/show"
-      },
-      "user_input": "params[:id]",
-      "confidence": "Weak",
-      "note": ""
-    },
-    {
-      "warning_type": "Cross-Site Scripting",
-      "warning_code": 2,
-      "fingerprint": "4f368ea80187b33fbb0d40d9f1c2768fde28c9f377bfaa857d2565e3746926a1",
-      "check_name": "CrossSiteScripting",
-      "message": "Unescaped parameter value",
-      "file": "app/views/view_data/services/show.html.erb",
-      "line": 45,
-      "link": "http://brakemanscanner.org/docs/warning_types/cross_site_scripting",
-      "code": "\"service\".where(:natural_key => params[:id]).first!.typical_users",
-      "render_path": [{"type":"controller","class":"ViewData::ServicesController","method":"show","line":18,"file":"app/controllers/view_data/services_controller.rb"}],
-      "location": {
-        "type": "template",
-        "template": "view_data/services/show"
+        "template": "view_data/delivery_organisations/show"
       },
       "user_input": "params[:id]",
       "confidence": "Weak",
@@ -45,10 +26,10 @@
       "check_name": "Render",
       "message": "Render path contains parameter value",
       "file": "app/views/view_data/services/show.html.erb",
-      "line": 81,
+      "line": 76,
       "link": "http://brakemanscanner.org/docs/warning_types/dynamic_render_path/",
       "code": "render(action => MetricsPresenter.new(\"service\".where(:natural_key => params[:id]).first!, :group_by => \"service\").metric_groups.last.metrics, { :metric_group => MetricsPresenter.new(\"service\".where(:natural_key => params[:id]).first!, :group_by => \"service\").metric_groups.last })",
-      "render_path": [{"type":"controller","class":"ViewData::ServicesController","method":"show","line":18,"file":"app/controllers/view_data/services_controller.rb"}],
+      "render_path": [{"type":"controller","class":"ViewData::ServicesController","method":"show","line":20,"file":"app/controllers/view_data/services_controller.rb"}],
       "location": {
         "type": "template",
         "template": "view_data/services/show"
@@ -58,25 +39,25 @@
       "note": ""
     },
     {
-      "warning_type": "Cross-Site Scripting",
-      "warning_code": 2,
-      "fingerprint": "c7ec077e96e611819046139d1b410ec2a1b80c3a275b554c5cbb6785d1ed1f8a",
-      "check_name": "CrossSiteScripting",
-      "message": "Unescaped parameter value",
-      "file": "app/views/view_data/services/show.html.erb",
-      "line": 42,
-      "link": "http://brakemanscanner.org/docs/warning_types/cross_site_scripting",
-      "code": "\"service\".where(:natural_key => params[:id]).first!.how_it_works",
-      "render_path": [{"type":"controller","class":"ViewData::ServicesController","method":"show","line":18,"file":"app/controllers/view_data/services_controller.rb"}],
+      "warning_type": "Dynamic Render Path",
+      "warning_code": 15,
+      "fingerprint": "aa0d7136b76a2f563c2950e93adbac7ab65afb9e838951f7e33ce23a8fdfd140",
+      "check_name": "Render",
+      "message": "Render path contains parameter value",
+      "file": "app/views/view_data/departments/show.html.erb",
+      "line": 49,
+      "link": "http://brakemanscanner.org/docs/warning_types/dynamic_render_path/",
+      "code": "render(action => MetricsPresenter.new(\"department\".where(:natural_key => params[:id]).first!, :group_by => \"department\").metric_groups.last.metrics, { :metric_group => MetricsPresenter.new(\"department\".where(:natural_key => params[:id]).first!, :group_by => \"department\").metric_groups.last })",
+      "render_path": [{"type":"controller","class":"ViewData::DepartmentsController","method":"show","line":14,"file":"app/controllers/view_data/departments_controller.rb"}],
       "location": {
         "type": "template",
-        "template": "view_data/services/show"
+        "template": "view_data/departments/show"
       },
       "user_input": "params[:id]",
       "confidence": "Weak",
       "note": ""
     }
   ],
-  "updated": "2017-11-22 14:25:24 +0000",
+  "updated": "2017-12-08 10:33:30 +0000",
   "brakeman_version": "4.0.1"
 }

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -41,6 +41,8 @@ Rails.application.routes.draw do
       end
 
       resources :services, only: [:show], controller: 'view_data/services'
+      resources :departments, only: [:show], controller: 'view_data/departments'
+      resources :delivery_organisations, only: [:show], controller: 'view_data/delivery_organisations'
     end
   end
 

--- a/spec/features/viewing_delivery_organisations_spec.rb
+++ b/spec/features/viewing_delivery_organisations_spec.rb
@@ -1,0 +1,21 @@
+require 'rails_helper'
+
+RSpec.feature 'viewing department detail pages', type: :feature do
+  let(:time_period) { TimePeriod.default }
+
+  specify 'viewing delivery organisation details' do
+    department = FactoryGirl.create(:department, name: 'Department for Transport', natural_key: 'test')
+    delivery_organisation = FactoryGirl.create(:delivery_organisation, department: department, name: 'Highways England')
+    service1 = FactoryGirl.create(:service, delivery_organisation: delivery_organisation, name: 'Pay the Dartford Crossing charge (Dartcharge)')
+    service2 = FactoryGirl.create(:service, delivery_organisation: delivery_organisation, name: 'Register for Dartcharge')
+
+    FactoryGirl.create(:monthly_service_metrics, :published, service: service1, month: time_period.start_month, online_transactions: 4025000, transactions_processed: 1437500)
+    FactoryGirl.create(:monthly_service_metrics, :published, service: service2, month: time_period.end_month, online_transactions: 1725000, transactions_processed: 4312500)
+
+    visit view_data_delivery_organisation_path(id: delivery_organisation.natural_key)
+
+    expect(page).to have_content('Department for Transport')
+    expect(page).to have_content('Detailed data for Highways England')
+    expect(page).to have_content('2 services')
+  end
+end

--- a/spec/features/viewing_departments_spec.rb
+++ b/spec/features/viewing_departments_spec.rb
@@ -1,0 +1,21 @@
+require 'rails_helper'
+
+RSpec.feature 'viewing department detail pages', type: :feature do
+  let(:time_period) { TimePeriod.default }
+
+  specify 'viewing department details' do
+    department = FactoryGirl.create(:department, name: 'Department for Transport', natural_key: 'test')
+    delivery_organisation = FactoryGirl.create(:delivery_organisation, department: department, name: 'Highways England')
+    service1 = FactoryGirl.create(:service, delivery_organisation: delivery_organisation, name: 'Pay the Dartford Crossing charge (Dartcharge)')
+    service2 = FactoryGirl.create(:service, delivery_organisation: delivery_organisation, name: 'Register for Dartcharge')
+
+    FactoryGirl.create(:monthly_service_metrics, :published, service: service1, month: time_period.start_month, online_transactions: 4025000, transactions_processed: 1437500)
+    FactoryGirl.create(:monthly_service_metrics, :published, service: service2, month: time_period.end_month, online_transactions: 1725000, transactions_processed: 4312500)
+
+    visit view_data_department_path(id: department.natural_key)
+
+    expect(page).to have_content('Detailed data for Department for Transport')
+    expect(page).to have_content('1 delivery organisation')
+    expect(page).to have_content('2 services')
+  end
+end


### PR DESCRIPTION
Adds two pages, one for departments and one for delivery organisations
which will eventually hold charts of the data for each metric item. For
now these pages just show the aggregated data and don't yet contain
information on the department type and brief overview of what the
dept or agency does.

Also includes some simple tests that it's working, that can be expanded
to check the charts when implemented