### PR TITLE
Add other field to publish form

### DIFF
--- a/app/admin/service.rb
+++ b/app/admin/service.rb
@@ -27,6 +27,12 @@ ActiveAdmin.register Service do
       row :natural_key
       row :created_at
       row :updated_at
+      row "Label for other field" do |service|
+        service.other_name || ""
+      end
+      row "Label for other calls field" do |service|
+        service.calls_other_name || ""
+      end
     end
 
     attributes_table title: "Contextual information" do
@@ -108,6 +114,8 @@ ActiveAdmin.register Service do
       f.input :delivery_organisation
       f.input :owner
       f.input :natural_key
+      f.input :other_name, as: :string, label: "Other transactions label"
+      f.input :calls_other_name, as: :string, label: "Other calls label"
       f.input :purpose, as: :pagedown_text
       f.input :how_it_works, as: :pagedown_text
       f.input :typical_users, as: :pagedown_text
@@ -157,7 +165,8 @@ ActiveAdmin.register Service do
                 :transactions_processed_applicable, :transactions_processed_with_intended_outcome_applicable,
                 :calls_received_applicable, :calls_received_get_information_applicable,
                 :calls_received_chase_progress_applicable, :calls_received_challenge_decision_applicable,
-                :calls_received_other_applicable, :calls_received_perform_transaction_applicable
+                :calls_received_other_applicable, :calls_received_perform_transaction_applicable,
+                :other_name, :calls_other_name
 
   remove_filter :online_transactions_applicable, :phone_transactions_applicable,
                 :paper_transactions_applicable,  :face_to_face_transactions_applicable,

--- a/app/controllers/publish_data/monthly_service_metrics_controller.rb
+++ b/app/controllers/publish_data/monthly_service_metrics_controller.rb
@@ -13,7 +13,17 @@ module PublishData
         :other_transactions, :transactions_processed, :transactions_processed_with_intended_outcome,
         :calls_received, :calls_received_perform_transaction, :calls_received_get_information,
         :calls_received_chase_progress, :calls_received_challenge_decision,
-        :calls_received_other).each { |_, value| value.gsub!(/\D/, '') }
+        :calls_received_other).each { |_key, value| value.gsub!(/\D/, '') }
+
+      begin
+        svc = @monthly_service_metrics.service
+        svc.attributes = params.require(:services).permit(:other_name, :calls_other_name).each { |_, value| value }
+        svc.save
+      rescue => _e
+        # It's possible that the :services fields are not set as they are not relevant
+        # so we will allow them to fail here.
+        logger.info("Metrics provided with no detail for other labels")
+      end
 
       if @monthly_service_metrics.save
         render 'publish_data/monthly_service_metrics/success'

--- a/app/helpers/form_helper.rb
+++ b/app/helpers/form_helper.rb
@@ -9,13 +9,13 @@ module FormHelper
       end
     end
 
-    def metric(name, applicable: true)
+    def metric(name, applicable: true, label: nil)
       return '' unless applicable
 
-      label = I18n.translate(name, scope: %w(helpers label monthly_service_metrics))
+      lbl = label || I18n.translate(name, scope: %w(helpers label monthly_service_metrics))
 
       @template.content_tag(:div, class: 'form-group') do
-        label(name, label, class: 'form-label') + number_field(name, class: 'form-control form-control-1-4')
+        label(name, lbl, class: 'form-label') + number_field(name, class: 'form-control form-control-1-4')
       end
     end
   end

--- a/app/helpers/metric_formatter_helper.rb
+++ b/app/helpers/metric_formatter_helper.rb
@@ -1,11 +1,15 @@
 module MetricFormatterHelper
   def metric_to_human(value)
-    text = number_to_human(value, precision: 3, significant: true, units: { thousand: 'k', million: 'm', billion: 'b' }, format: '%n%u')
-    content_tag(:data, text, value: value)
+    if value == :not_provided
+      content_tag(:data, "Not provided", value: "", class: "metric-value-not-provided")
+    else
+      text = number_to_human(value, precision: 3, significant: true, units: { thousand: 'k', million: 'm', billion: 'b' }, format: '%n%u')
+      content_tag(:data, text, value: value)
+    end
   end
 
   def metric_to_percentage(value)
-    return 0 if value == :not_applicable
+    return 0 if %i(not_applicable not_provided).include? value
     return number_to_percentage(0, precision: 1) if value.nan?
     number_to_percentage(value, precision: 1)
   end

--- a/app/helpers/metric_item_helper.rb
+++ b/app/helpers/metric_item_helper.rb
@@ -1,7 +1,6 @@
 module MetricItemHelper
   def metric_item(metric_item, metric_value, sampled: false, html: {})
     return if metric_value == Metric::NOT_APPLICABLE
-
     item = MetricItemContent.new(self, metric_value)
     content = capture { yield(item) } || ''
 

--- a/app/models/metrics.rb
+++ b/app/models/metrics.rb
@@ -81,9 +81,13 @@ class Metrics
     def initialize(entity, metrics_by_month)
       @entity = entity
       @metrics_by_month = metrics_by_month
+      @service = nil
+      if entity.class == Service
+        @service = entity
+      end
     end
 
-    attr_reader :entity, :metrics_by_month
+    attr_reader :entity, :metrics_by_month, :service
 
     def transactions_received_metric
       metrics.map(&:transactions_received_metric).reduce(:+)
@@ -106,7 +110,7 @@ class Metrics
 
   def initialize(root, group_by:, time_period:)
     @root = root
-    @group_by = group_by
+    @group_by = group_by || GroupBy::Service
     @time_period = time_period
   end
 

--- a/app/presenters/metric_group_presenter.rb
+++ b/app/presenters/metric_group_presenter.rb
@@ -24,6 +24,10 @@ class MetricGroupPresenter
       end
     end
 
+    def service
+      nil
+    end
+
     def entity
       @entity.extend(EntityToPartialPath)
     end
@@ -38,6 +42,10 @@ class MetricGroupPresenter
     @entity = metric_group.entity
     @collapsed = collapsed
     @sort_value = sort_value
+    @service = nil
+    if @entity.class == Service
+      @service = @entity
+    end
   end
 
   def entity
@@ -46,7 +54,7 @@ class MetricGroupPresenter
 
   delegate :name, to: :entity
 
-  attr_reader :sort_value
+  attr_reader :sort_value, :service
 
   def metrics
     @metrics ||= [transactions_received_metric, transactions_processed_metric, calls_received_metric].each { |metric| metric.extend(MetricToPartialPath) }

--- a/app/views/publish_data/monthly_service_metrics/edit.html.erb
+++ b/app/views/publish_data/monthly_service_metrics/edit.html.erb
@@ -19,7 +19,25 @@
           <%= f.metric :phone_transactions, applicable: @monthly_service_metrics.service.phone_transactions_applicable %>
           <%= f.metric :paper_transactions, applicable: @monthly_service_metrics.service.paper_transactions_applicable %>
           <%= f.metric :face_to_face_transactions, applicable: @monthly_service_metrics.service.face_to_face_transactions_applicable %>
-          <%= f.metric :other_transactions, applicable: @monthly_service_metrics.service.other_transactions_applicable %>
+
+          <% if @monthly_service_metrics.service.other_transactions_applicable %>
+            <p>
+              If you receive transactions through another channel, please enter the
+              name of the channel and the transactions received here.
+            </p>
+
+            <div class="form-group">
+              <label class="form-label" for="services_other_name">
+                Name of 'other' channel
+              </label>
+              <%= text_field(:services, :other_name,
+                class: "form-control form-control-1-6",
+                value: @monthly_service_metrics.service.other_name) %>
+            </div>
+          <% end %>
+
+
+          <%= f.metric :other_transactions, applicable: @monthly_service_metrics.service.other_transactions_applicable, label: "Transactions received through this channel" %>
         <% end %>
 
         <%= f.fieldset 'Number of transactions processed' do %>
@@ -39,8 +57,29 @@
           <%= f.metric :calls_received_get_information, applicable: @monthly_service_metrics.service.calls_received_get_information_applicable %>
           <%= f.metric :calls_received_chase_progress, applicable: @monthly_service_metrics.service.calls_received_chase_progress_applicable %>
           <%= f.metric :calls_received_challenge_decision, applicable: @monthly_service_metrics.service.calls_received_challenge_decision_applicable %>
-          <%= f.metric :calls_received_other, applicable: @monthly_service_metrics.service.calls_received_other_applicable %>
+
+
+          <% if @monthly_service_metrics.service.calls_received_other_applicable %>
+            <p>
+              If you receive phone calls for other reasons, please enter the reason
+              and the number of calls here.
+            </p>
+
+            <div class="form-group">
+              <label class="form-label" for="services_calls_other_name">
+                Reason for calling
+              </label>
+              <%= text_field(:services, :calls_other_name,
+                class: "form-control form-control-1-6",
+                value: @monthly_service_metrics.service.calls_other_name) %>
+            </div>
+          <% end %>
+
+
+          <%= f.metric :calls_received_other, applicable: @monthly_service_metrics.service.calls_received_other_applicable, label: "Number of telephone calls for this reason" %>
+
         <% end %>
+
 
         <p>
           <%= f.submit 'Submit', id: 'submit-data', class: 'button' %>

--- a/app/views/publish_data/monthly_service_metrics/preview.html.erb
+++ b/app/views/publish_data/monthly_service_metrics/preview.html.erb
@@ -6,7 +6,7 @@
       </h1>
       <p>
         You can share the URL of this page with your colleagues. The most recent month's data is not yet published — it will go live on <%= @monthly_service_metrics.publish_date.to_formatted_s(:long_day_month_year) %>.
-      </p>  
+      </p>
       <p>
         <a href="monitor"><%= link_to 'Go back', publish_service_metrics_path(publish_token: params[:publish_token]) %></a>
       </p>

--- a/app/views/view_data/metrics/_calls_received_metric.html.erb
+++ b/app/views/view_data/metrics/_calls_received_metric.html.erb
@@ -87,7 +87,13 @@
         <strong><%= metric_to_human(calls_received_metric.other) %></strong> other calls received (<%= metric_to_percentage(calls_received_metric.other_percentage) %>)
       <% end %>
 
-      <span class="metric-name">Other</span>
+      <span class="metric-name"><%=
+        if metric_group.service && !metric_group.service.calls_other_name.blank?
+          metric_group.service.calls_other_name.capitalize
+        else
+          "Other"
+        end %>
+      </span>
       <span class="metric-value">
         <%= item.value %>
         <%= item.percentage calls_received_metric.other_percentage %>

--- a/app/views/view_data/metrics/_transactions_received_metric.html.erb
+++ b/app/views/view_data/metrics/_transactions_received_metric.html.erb
@@ -80,7 +80,14 @@
         <strong><%= metric_to_human(transactions_received_metric.other) %></strong> other transactions (<%= metric_to_percentage(transactions_received_metric.other_percentage) %>)
       <% end %>
 
-      <span class="metric-name">Other</span>
+      <span class="metric-name"><%=
+        if metric_group.service && !metric_group.service.other_name.blank?
+          metric_group.service.other_name.capitalize
+        else
+          "Other"
+        end
+        %>
+      </span>
       <span class="metric-value">
         <%= item.value %>
         <%= item.percentage transactions_received_metric.other_percentage %>

--- a/db/migrate/20171227101246_add_other_label_fields.rb
+++ b/db/migrate/20171227101246_add_other_label_fields.rb
@@ -1,0 +1,6 @@
+class AddOtherLabelFields < ActiveRecord::Migration[5.1]
+  def change
+    add_column :services, :calls_other_name, :text
+    add_column :services, :other_name, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171205160414) do
+ActiveRecord::Schema.define(version: 20171227101246) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -116,6 +116,8 @@ ActiveRecord::Schema.define(version: 20171205160414) do
     t.boolean "calls_received_perform_transaction_applicable", default: true
     t.integer "delivery_organisation_id", null: false
     t.integer "owner_id"
+    t.text "calls_other_name"
+    t.text "other_name"
     t.index ["natural_key"], name: "index_services_on_natural_key", unique: true
     t.index ["publish_token"], name: "index_services_on_publish_token", unique: true
   end

--- a/spec/controllers/publish_data/monthly_service_metrics_controller_spec.rb
+++ b/spec/controllers/publish_data/monthly_service_metrics_controller_spec.rb
@@ -45,13 +45,24 @@ RSpec.describe PublishData::MonthlyServiceMetricsController, type: :controller d
 
   describe 'PATCH update' do
     def dispatch
-      patch :update, params: { service_id: service.id, year: '2017', month: '06', publish_token: publish_token, metrics: metrics_params }
+      patch :update, params: {
+        service_id: service.id, year: '2017', month: '06', publish_token: publish_token, metrics: metrics_params,
+        services: { 'other_name' => 'Other', 'calls_other_name' => 'Other' }
+      }
     end
 
     let(:publish_token) { 'PuBlIsHtOkEn' }
     let(:metrics_params) { { 'online_transactions' => '1000' } }
-    let(:metrics) { instance_double(MonthlyServiceMetrics, :service= => nil, :month= => nil, :attributes= => nil) }
     let(:service) { instance_double(Service, id: '01') }
+    let(:metrics) {
+      s = instance_double(Service, id: '01')
+      allow(s).to receive(:attributes=) {}
+      allow(s).to receive(:save) { true }
+
+      m = instance_double(MonthlyServiceMetrics, :service= => s, :month= => nil, :attributes= => nil)
+      allow(m).to receive(:service) { s }
+      m
+    }
 
     before do
       allow(MonthlyServiceMetrics).to receive_message_chain(:where, :first_or_initialize) { metrics }

--- a/spec/features/submitting_monthly_service_metrics_spec.rb
+++ b/spec/features/submitting_monthly_service_metrics_spec.rb
@@ -15,7 +15,7 @@ RSpec.feature 'submitting monthly service metrics' do
       fill_in 'Phone', with: '17,000'
       fill_in 'Paper', with: '16,000'
       fill_in 'Face-to-face', with: '15,000'
-      fill_in 'Other', with: '14,000'
+      fill_in 'Transactions received through this channel', with: '14,000'
     end
 
     within_fieldset('Number of transactions processed') do
@@ -35,7 +35,7 @@ RSpec.feature 'submitting monthly service metrics' do
       fill_in 'to get information', with: '10,000'
       fill_in 'to chase progress', with: '9,000'
       fill_in 'to challenge a decision', with: '8,000'
-      fill_in 'Other', with: '7,000'
+      fill_in 'Number of telephone calls for this reason', with: '7,000'
     end
 
     click_button 'Submit'


### PR DESCRIPTION
We've now added a new field (to the service) so that we can record what the 'Other' fields mean by asking the user to tell us. Unfortunately this is only useful on the service context page, or the list of services - departments and delivery organisations group together lots of services, so which label would we show? 

There isn't any validation yet (if you fill in the Other field you MUST provide a label) but this will probably happen when we do the rest of the validation (phone calls and transactions by phone should be the same).  

We are unable to add new other fields as required as this is quite a big change away from our fixed collection of metrics.