### PR TITLE
Adds skeleton pages for footer items

### DIFF
--- a/app/controllers/view_data/pages_controller.rb
+++ b/app/controllers/view_data/pages_controller.rb
@@ -11,5 +11,11 @@ module ViewData
     def transactions_received_help; end
 
     def calls_received_help; end
+
+    def cookies; end
+
+    def privacy; end
+
+    def terms; end
   end
 end

--- a/app/views/layouts/view_data.html.erb
+++ b/app/views/layouts/view_data.html.erb
@@ -68,6 +68,14 @@
         <div class="footer-meta">
           <div class="footer-meta-inner">
 
+            <ul>
+              <li><a href="/help/cookies">Cookies</a></li>
+              <li><a href="/help/privacy-policy">Privacy policy</a></li>
+              <li><a href="/help/terms-conditions">Terms and conditions</a></li>
+              <li>Built by the <a href="https://www.gov.uk/government/organisations/government-digital-service">Government Digital Service</a>
+              </li>
+            </ul>
+
             <div class="open-government-licence">
               <p class="logo"><a href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/" rel="license">Open Government Licence</a></p>
                 <p>All content is available under the <a href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/" rel="license">Open Government Licence v3.0</a>, except where otherwise stated</p>

--- a/app/views/view_data/pages/cookies.html.erb
+++ b/app/views/view_data/pages/cookies.html.erb
@@ -1,0 +1,79 @@
+<main id="content" role="main">
+
+  <div class="grid-row">
+    <div class="column-full">
+      <h1 class="heading-large">
+        Cookies
+      </h1>
+    </div>
+  </div>
+
+  <br/>
+
+  <div class="grid-row">
+    <div class="column-two-thirds">
+      <p>
+         Service Performance puts small files (known as ‘cookies’) onto your computer to collect information about how you browse the site.
+      </p>
+
+      <p>Cookies are used to:</p>
+
+      <ul class="list list-bullet">
+        <li>measure how you use the website so it can be updated and improved based on your needs</li>
+        <li>remember the options you've chosen</li>
+      </ul>
+
+      <h1 class="heading-medium">Service performance cookies aren’t used to identify you personally</h1>
+      <p>You’ll normally see a message on the site before we store a cookie on your computer.</p>
+    </div>
+  </div>
+
+  <div class="grid-row">
+    <div class="column-two-thirds">
+      <h1 class="heading-large">How cookies are used</h1>
+      <h1 class="heading-medium">Measuring website usage (Google Analytics)</h1>
+
+      <p>We use Google Analytics software to collect information about how you use Service Performance. We do this to help make sure the site is meeting the needs of its users and to help us make improvements, for example, improving user journeys.</p>
+
+      <p>Google Analytics stores information about:</p>
+
+      <ul class="list list-bullet">
+        <li>the pages you visit on the site</li>
+        <li>how long you spend on each page</li>
+        <li>how you got to the site</li>
+        <li>what you click on while you’re visiting the site</li>
+      </ul>
+
+      <p>We don’t collect or store your personal information (such as your name or address) so this information can’t be used to identify who you are.</p>
+
+      <h1 class="heading-medium">We don’t allow Google to use or share our analytics data</h1>
+
+      <p>Google Analytics sets the following cookies:
+        <table>
+          <thead>
+            <tr>
+              <th>Name</th>
+              <th>Purpose</th>
+              <th>Expires</th>
+            </tr>
+          </thead>
+          <tbody>
+          <tr>
+            <td>_ga</td>
+            <td>This helps us count how many people visit the site by tracking if you’ve visited before</td>
+            <td>2 years</td>
+          </tr>
+          <tr>
+            <td>_gat</td>
+            <td>Used to manage the rate at which page view requests are made</td>
+            <td>10 minutes</td>
+          </tr>
+          </tbody>
+        </table>
+      </p>
+
+      <p>You can <a href="https://tools.google.com/dlpage/gaoptout">opt out of Google Analytics cookies.</a></p>
+    </div>
+  </div>
+
+</main>

--- a/app/views/view_data/pages/cookies.html.erb
+++ b/app/views/view_data/pages/cookies.html.erb
@@ -8,8 +8,6 @@
     </div>
   </div>
 
-  <br/>
-
   <div class="grid-row">
     <div class="column-two-thirds">
       <p>

--- a/app/views/view_data/pages/privacy.html.erb
+++ b/app/views/view_data/pages/privacy.html.erb
@@ -1,0 +1,13 @@
+<main id="content" role="main">
+
+  <div class="grid-row">
+    <div class="column-full">
+      <h1 class="heading-xlarge">
+        Privacy policy
+      </h1>
+    </div>
+  </div>
+
+
+
+</main>

--- a/app/views/view_data/pages/terms.html.erb
+++ b/app/views/view_data/pages/terms.html.erb
@@ -1,0 +1,13 @@
+<main id="content" role="main">
+
+  <div class="grid-row">
+    <div class="column-full">
+      <h1 class="heading-xlarge">
+        Terms and Conditions
+      </h1>
+    </div>
+  </div>
+
+
+
+</main>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -24,6 +24,10 @@ Rails.application.routes.draw do
     get "/help/transactions-processed", to: "view_data/pages#transactions_processed_help"
     get "/help/calls-received", to: "view_data/pages#calls_received_help"
 
+    get "/help/cookies", to: "view_data/pages#cookies"
+    get "/help/terms-conditions", to: "view_data/pages#terms"
+    get "/help/privacy-policy", to: "view_data/pages#privacy"
+
     scope 'performance-data' do
       scope :government do
         get 'metrics/:group_by', to: 'view_data/government_metrics#index',

--- a/spec/controllers/view_data/page_controller_spec.rb
+++ b/spec/controllers/view_data/page_controller_spec.rb
@@ -8,5 +8,20 @@ RSpec.describe ViewData::PagesController, type: :controller do
       get :homepage
       expect(page.title).to match(/\AService Performance/)
     end
+
+    it 'has a cookie page' do
+      get :cookies
+      expect(controller).to have_rendered('view_data/pages/cookies')
+    end
+
+    it 'has a privacy policy page' do
+      get :privacy
+      expect(controller).to have_rendered('view_data/pages/privacy')
+    end
+
+    it 'has a terms and conditions page' do
+      get :terms
+      expect(controller).to have_rendered('view_data/pages/terms')
+    end
   end
 end


### PR DESCRIPTION
This PR adds footer items for:

* A privacy policy page
* A cookies page
* A terms and conditions page

They are currently mostly empty (except the cookies page) and we will
need to find content before these are at all usable.