### PR TITLE
Extends the TimePeriod model for previous time periods

### DIFF
--- a/app/models/time_period.rb
+++ b/app/models/time_period.rb
@@ -28,9 +28,8 @@ class TimePeriod
     YearMonth.new(ends_on.year, ends_on.month)
   end
 
-  # Obtain the duration between the start and end of the time period
-  # in months. This is the number of months covered by the range.
-  def duration
+  # Obtain the number of months that this date range covers.
+  def months_covered
     (@ends_on.year * 12 + @ends_on.month) - (@starts_on.year * 12 + @starts_on.month) + 1
   end
 

--- a/app/models/time_period.rb
+++ b/app/models/time_period.rb
@@ -34,10 +34,14 @@ class TimePeriod
     (@ends_on.year * 12 + @ends_on.month) - (@starts_on.year * 12 + @starts_on.month) + 1
   end
 
-  # Retrieve the time period for that precedes the current time
-  # period.
+  # Retrieve the time period that precedes the current period.
+  # This time period should match the month range so if current period is
+  # Jan-Mar 2017 the previous period is Jan-Mar 2016. If current period is
+  # Oct 2016 - Feb 2017 then the previous period is Oct 2015 - Feb 2016.
   def previous_period
-    d = duration
-    TimePeriod.new(@starts_on.dup.advance(months: -d), @ends_on.dup.advance(months: -d))
+    TimePeriod.new(
+      @starts_on.dup.advance(months: -12),
+      @ends_on.dup.advance(months: -12)
+    )
   end
 end

--- a/app/models/time_period.rb
+++ b/app/models/time_period.rb
@@ -27,4 +27,17 @@ class TimePeriod
   def end_month
     YearMonth.new(ends_on.year, ends_on.month)
   end
+
+  # Obtain the duration between the start and end of the time period
+  # in months. This is the number of months covered by the range.
+  def duration
+    (@ends_on.year * 12 + @ends_on.month) - (@starts_on.year * 12 + @starts_on.month) + 1
+  end
+
+  # Retrieve the time period for that precedes the current time
+  # period.
+  def previous_period
+    d = duration
+    TimePeriod.new(@starts_on.dup.advance(months: -d), @ends_on.dup.advance(months: -d))
+  end
 end

--- a/spec/models/time_period_spec.rb
+++ b/spec/models/time_period_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe TimePeriod, type: :model do
   describe '#duration' do
     it 'correctly returns the duration for a valid time period' do
       period = TimePeriod.new(Date.new(2017, 10, 1), Date.new(2017, 11, 30))
-      expect(period.duration).to eq(2)
+      expect(period.months_covered).to eq(2)
     end
   end
 
@@ -42,7 +42,7 @@ RSpec.describe TimePeriod, type: :model do
     it 'can return the previous period for short periods' do
       period = TimePeriod.new(Date.new(2017, 1, 1), Date.new(2017, 3, 30))
       new_period = period.previous_period
-      expect(new_period.duration).to eq(period.duration)
+      expect(new_period.months_covered).to eq(period.months_covered)
       expect(new_period.starts_on.month).to eq(1)
       expect(new_period.starts_on.year).to eq(period.starts_on.year - 1)
       expect(new_period.ends_on.month).to eq(3)
@@ -52,7 +52,7 @@ RSpec.describe TimePeriod, type: :model do
     it 'can return the previous period for periods that wrap across a year' do
       period = TimePeriod.new(Date.new(2016, 10, 1), Date.new(2017, 3, 30))
       new_period = period.previous_period
-      expect(new_period.duration).to eq(period.duration)
+      expect(new_period.months_covered).to eq(period.months_covered)
       expect(new_period.starts_on.month).to eq(10)
       expect(new_period.starts_on.year).to eq(period.starts_on.year - 1)
       expect(new_period.ends_on.month).to eq(3)

--- a/spec/models/time_period_spec.rb
+++ b/spec/models/time_period_spec.rb
@@ -30,4 +30,33 @@ RSpec.describe TimePeriod, type: :model do
       expect(period.end_month).to eq(YearMonth.new(2017, 11))
     end
   end
+
+  describe '#duration' do
+    it 'correctly returns the duration for a valid time period' do
+      period = TimePeriod.new(Date.new(2017, 10, 1), Date.new(2017, 11, 30))
+      expect(period.duration).to eq(2)
+    end
+  end
+
+  describe '#previous_period' do
+    it 'can return the previous period for short periods' do
+      period = TimePeriod.new(Date.new(2017, 10, 1), Date.new(2017, 11, 30))
+      new_period = period.previous_period
+      expect(new_period.duration).to eq(period.duration)
+      expect(new_period.starts_on.month).to eq(8)
+      expect(new_period.ends_on.month).to eq(9)
+      expect(new_period.starts_on.day).to eq(1)
+      expect(new_period.ends_on.day).to eq(30)
+    end
+
+    it 'can return the previous period for long periods' do
+      period = TimePeriod.new(Date.new(2016, 12, 1), Date.new(2017, 11, 30))
+      new_period = period.previous_period
+      expect(new_period.duration).to eq(period.duration)
+      expect(new_period.starts_on.month).to eq(12)
+      expect(new_period.ends_on.month).to eq(11)
+      expect(new_period.starts_on.year).to eq(2015)
+      expect(new_period.ends_on.year).to eq(2016)
+    end
+  end
 end

--- a/spec/models/time_period_spec.rb
+++ b/spec/models/time_period_spec.rb
@@ -40,23 +40,23 @@ RSpec.describe TimePeriod, type: :model do
 
   describe '#previous_period' do
     it 'can return the previous period for short periods' do
-      period = TimePeriod.new(Date.new(2017, 10, 1), Date.new(2017, 11, 30))
+      period = TimePeriod.new(Date.new(2017, 1, 1), Date.new(2017, 3, 30))
       new_period = period.previous_period
       expect(new_period.duration).to eq(period.duration)
-      expect(new_period.starts_on.month).to eq(8)
-      expect(new_period.ends_on.month).to eq(9)
-      expect(new_period.starts_on.day).to eq(1)
-      expect(new_period.ends_on.day).to eq(30)
+      expect(new_period.starts_on.month).to eq(1)
+      expect(new_period.starts_on.year).to eq(period.starts_on.year - 1)
+      expect(new_period.ends_on.month).to eq(3)
+      expect(new_period.ends_on.year).to eq(period.ends_on.year - 1)
     end
 
-    it 'can return the previous period for long periods' do
-      period = TimePeriod.new(Date.new(2016, 12, 1), Date.new(2017, 11, 30))
+    it 'can return the previous period for periods that wrap across a year' do
+      period = TimePeriod.new(Date.new(2016, 10, 1), Date.new(2017, 3, 30))
       new_period = period.previous_period
       expect(new_period.duration).to eq(period.duration)
-      expect(new_period.starts_on.month).to eq(12)
-      expect(new_period.ends_on.month).to eq(11)
-      expect(new_period.starts_on.year).to eq(2015)
-      expect(new_period.ends_on.year).to eq(2016)
+      expect(new_period.starts_on.month).to eq(10)
+      expect(new_period.starts_on.year).to eq(period.starts_on.year - 1)
+      expect(new_period.ends_on.month).to eq(3)
+      expect(new_period.ends_on.year).to eq(period.ends_on.year - 1)
     end
   end
 end


### PR DESCRIPTION
As we will need to be able to obtain data from previous time periods
this PR extends the TimePeriod model to be able to do that.

This time period should match the month range so if current period is
Jan-Mar 2017 the previous period is Jan-Mar 2016. If current period is
Oct 2016 - Feb 2017 then the previous period is Oct 2015 - Feb 2016.
