### PR TITLE
Time period defaults and serialisation

### DIFF
--- a/app/controllers/view_data/delivery_organisation_metrics_controller.rb
+++ b/app/controllers/view_data/delivery_organisation_metrics_controller.rb
@@ -2,7 +2,7 @@ module ViewData
   class DeliveryOrganisationMetricsController < MetricsController
     def index
       delivery_organisation = DeliveryOrganisation.where(natural_key: params[:delivery_organisation_id]).first!
-      @metrics = MetricsPresenter.new(delivery_organisation, group_by: group_by, order: order, order_by: order_by)
+      @metrics = MetricsPresenter.new(delivery_organisation, group_by: group_by, order: order, order_by: order_by, time_period: time_period)
 
       page.breadcrumbs << Page::Crumb.new('UK Government', view_data_government_metrics_path)
       page.breadcrumbs << Page::Crumb.new(delivery_organisation.department.name, view_data_department_metrics_path(department_id: delivery_organisation.department))

--- a/app/controllers/view_data/delivery_organisations_controller.rb
+++ b/app/controllers/view_data/delivery_organisations_controller.rb
@@ -3,7 +3,7 @@ module ViewData
     def show
       @delivery_organisation = DeliveryOrganisation.where(natural_key: params[:id]).first!
 
-      @metrics = MetricsPresenter.new(@delivery_organisation, group_by: Metrics::GroupBy::DeliveryOrganisation)
+      @metrics = MetricsPresenter.new(@delivery_organisation, group_by: Metrics::GroupBy::DeliveryOrganisation, time_period: time_period)
 
       page.title = @delivery_organisation.name
 

--- a/app/controllers/view_data/department_metrics_controller.rb
+++ b/app/controllers/view_data/department_metrics_controller.rb
@@ -2,7 +2,7 @@ module ViewData
   class DepartmentMetricsController < MetricsController
     def index
       department = Department.where(natural_key: params[:department_id]).first!
-      @metrics = MetricsPresenter.new(department, group_by: group_by, order: order, order_by: order_by)
+      @metrics = MetricsPresenter.new(department, group_by: group_by, order: order, order_by: order_by, time_period: time_period)
 
       page.breadcrumbs << Page::Crumb.new('UK Government', view_data_government_metrics_path)
       page.breadcrumbs << Page::Crumb.new(department.name)

--- a/app/controllers/view_data/departments_controller.rb
+++ b/app/controllers/view_data/departments_controller.rb
@@ -3,7 +3,7 @@ module ViewData
     def show
       @department = Department.where(natural_key: params[:id]).first!
 
-      @metrics = MetricsPresenter.new(@department, group_by: Metrics::GroupBy::Department)
+      @metrics = MetricsPresenter.new(@department, group_by: Metrics::GroupBy::Department, time_period: time_period)
 
       page.title = @department.name
 

--- a/app/controllers/view_data/government_metrics_controller.rb
+++ b/app/controllers/view_data/government_metrics_controller.rb
@@ -2,7 +2,7 @@ module ViewData
   class GovernmentMetricsController < MetricsController
     def index
       government = Government.new
-      @metrics = MetricsPresenter.new(government, group_by: group_by, order_by: order_by, order: order)
+      @metrics = MetricsPresenter.new(government, group_by: group_by, order_by: order_by, order: order, time_period: time_period)
 
       page.breadcrumbs << Page::Crumb.new('UK Government')
 

--- a/app/controllers/view_data/services_controller.rb
+++ b/app/controllers/view_data/services_controller.rb
@@ -3,7 +3,7 @@ module ViewData
     def show
       @service = Service.where(natural_key: params[:id]).first!
 
-      @metrics = MetricsPresenter.new(@service, group_by: Metrics::GroupBy::Service)
+      @metrics = MetricsPresenter.new(@service, group_by: Metrics::GroupBy::Service, time_period: time_period)
 
       page.title = @service.name
 

--- a/app/controllers/view_data_controller.rb
+++ b/app/controllers/view_data_controller.rb
@@ -1,3 +1,9 @@
 class ViewDataController < ApplicationController
   layout 'view_data'
+
+private
+
+  def time_period
+    session[:time_period] || TimePeriod.default
+  end
 end

--- a/app/controllers/view_data_controller.rb
+++ b/app/controllers/view_data_controller.rb
@@ -4,6 +4,6 @@ class ViewDataController < ApplicationController
 private
 
   def time_period
-    session[:time_period] || TimePeriod.default
+    TimePeriod.deserialise(session[:time_period]) || TimePeriod.default
   end
 end

--- a/app/models/time_period.rb
+++ b/app/models/time_period.rb
@@ -9,6 +9,26 @@ class TimePeriod
     new(starts_on, ends_on)
   end
 
+  # Convert the object into a string that contains all of the
+  # information
+  def self.serialise(period)
+    "#{period.starts_on} #{period.ends_on}"
+  end
+
+  # Converts the provided string into a TimePeriod, but requires
+  # that the string was generated with self.serialise
+  def self.deserialise(input)
+    starts, ends = input.split
+    begin
+      TimePeriod.new(
+        Date.parse(starts),
+        Date.parse(ends)
+      )
+    rescue
+      nil
+    end
+  end
+
   def initialize(starts_on, ends_on)
     @starts_on = starts_on
     @ends_on = ends_on

--- a/app/models/time_period.rb
+++ b/app/models/time_period.rb
@@ -18,8 +18,8 @@ class TimePeriod
   # Converts the provided string into a TimePeriod, but requires
   # that the string was generated with self.serialise
   def self.deserialise(input)
-    starts, ends = input.split
     begin
+      starts, ends = input.split
       TimePeriod.new(
         Date.parse(starts),
         Date.parse(ends)

--- a/app/models/time_period.rb
+++ b/app/models/time_period.rb
@@ -63,4 +63,9 @@ class TimePeriod
       @ends_on.dup.advance(months: -12)
     )
   end
+
+  # Defines equality as the start and end dates being the same
+  def ==(o)
+    o.class == self.class && o.starts_on == @starts_on && o.ends_on == @ends_on
+  end
 end

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -3,17 +3,17 @@
     {
       "warning_type": "Dynamic Render Path",
       "warning_code": 15,
-      "fingerprint": "3edea751b1a949810f48aa2ab91497cc8d75cd0c072f1ac8276c7e4116a1e426",
+      "fingerprint": "2badd208d687dd6555c997acc699b73ea3ca9944e4a7783d3f9bd1fd6cfa333e",
       "check_name": "Render",
       "message": "Render path contains parameter value",
-      "file": "app/views/view_data/delivery_organisations/show.html.erb",
-      "line": 53,
+      "file": "app/views/view_data/departments/show.html.erb",
+      "line": 49,
       "link": "http://brakemanscanner.org/docs/warning_types/dynamic_render_path/",
-      "code": "render(action => MetricsPresenter.new(\"delivery_organisation\".where(:natural_key => params[:id]).first!, :group_by => \"delivery_organisation\").metric_groups.last.metrics, { :metric_group => MetricsPresenter.new(\"delivery_organisation\".where(:natural_key => params[:id]).first!, :group_by => \"delivery_organisation\").metric_groups.last })",
-      "render_path": [{"type":"controller","class":"ViewData::DeliveryOrganisationsController","method":"show","line":15,"file":"app/controllers/view_data/delivery_organisations_controller.rb"}],
+      "code": "render(action => MetricsPresenter.new(\"department\".where(:natural_key => params[:id]).first!, :group_by => \"department\", :time_period => time_period).metric_groups.last.metrics, { :metric_group => MetricsPresenter.new(\"department\".where(:natural_key => params[:id]).first!, :group_by => \"department\", :time_period => time_period).metric_groups.last })",
+      "render_path": [{"type":"controller","class":"ViewData::DepartmentsController","method":"show","line":14,"file":"app/controllers/view_data/departments_controller.rb"}],
       "location": {
         "type": "template",
-        "template": "view_data/delivery_organisations/show"
+        "template": "view_data/departments/show"
       },
       "user_input": "params[:id]",
       "confidence": "Weak",
@@ -22,13 +22,13 @@
     {
       "warning_type": "Dynamic Render Path",
       "warning_code": 15,
-      "fingerprint": "5d863c49c058787a9dabb55435f4538b9d759d13d94d2e60e67f8116ba8e9a4e",
+      "fingerprint": "703734658957394a93636417352c5b6f0309e89b8deb5d4de77dbd7166f12691",
       "check_name": "Render",
       "message": "Render path contains parameter value",
       "file": "app/views/view_data/services/show.html.erb",
       "line": 76,
       "link": "http://brakemanscanner.org/docs/warning_types/dynamic_render_path/",
-      "code": "render(action => MetricsPresenter.new(\"service\".where(:natural_key => params[:id]).first!, :group_by => \"service\").metric_groups.last.metrics, { :metric_group => MetricsPresenter.new(\"service\".where(:natural_key => params[:id]).first!, :group_by => \"service\").metric_groups.last })",
+      "code": "render(action => MetricsPresenter.new(\"service\".where(:natural_key => params[:id]).first!, :group_by => \"service\", :time_period => time_period).metric_groups.last.metrics, { :metric_group => MetricsPresenter.new(\"service\".where(:natural_key => params[:id]).first!, :group_by => \"service\", :time_period => time_period).metric_groups.last })",
       "render_path": [{"type":"controller","class":"ViewData::ServicesController","method":"show","line":20,"file":"app/controllers/view_data/services_controller.rb"}],
       "location": {
         "type": "template",
@@ -41,23 +41,23 @@
     {
       "warning_type": "Dynamic Render Path",
       "warning_code": 15,
-      "fingerprint": "aa0d7136b76a2f563c2950e93adbac7ab65afb9e838951f7e33ce23a8fdfd140",
+      "fingerprint": "a74c38e4876d630f1bf9725f62e82743574e2c4450d8addb66c9d08eaa30f9cd",
       "check_name": "Render",
       "message": "Render path contains parameter value",
-      "file": "app/views/view_data/departments/show.html.erb",
-      "line": 49,
+      "file": "app/views/view_data/delivery_organisations/show.html.erb",
+      "line": 53,
       "link": "http://brakemanscanner.org/docs/warning_types/dynamic_render_path/",
-      "code": "render(action => MetricsPresenter.new(\"department\".where(:natural_key => params[:id]).first!, :group_by => \"department\").metric_groups.last.metrics, { :metric_group => MetricsPresenter.new(\"department\".where(:natural_key => params[:id]).first!, :group_by => \"department\").metric_groups.last })",
-      "render_path": [{"type":"controller","class":"ViewData::DepartmentsController","method":"show","line":14,"file":"app/controllers/view_data/departments_controller.rb"}],
+      "code": "render(action => MetricsPresenter.new(\"delivery_organisation\".where(:natural_key => params[:id]).first!, :group_by => \"delivery_organisation\", :time_period => time_period).metric_groups.last.metrics, { :metric_group => MetricsPresenter.new(\"delivery_organisation\".where(:natural_key => params[:id]).first!, :group_by => \"delivery_organisation\", :time_period => time_period).metric_groups.last })",
+      "render_path": [{"type":"controller","class":"ViewData::DeliveryOrganisationsController","method":"show","line":15,"file":"app/controllers/view_data/delivery_organisations_controller.rb"}],
       "location": {
         "type": "template",
-        "template": "view_data/departments/show"
+        "template": "view_data/delivery_organisations/show"
       },
       "user_input": "params[:id]",
       "confidence": "Weak",
       "note": ""
     }
   ],
-  "updated": "2017-12-08 10:33:30 +0000",
+  "updated": "2018-01-16 09:18:40 +0000",
   "brakeman_version": "4.0.1"
 }

--- a/spec/controllers/view_data/delivery_organisation_metrics_controller_spec.rb
+++ b/spec/controllers/view_data/delivery_organisation_metrics_controller_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe ViewData::DeliveryOrganisationMetricsController, type: :controlle
 
     it 'assigns a DeliveryOrganisationMetrics presenter to @metrics' do
       presenter = instance_double(MetricsPresenter)
-      expect(MetricsPresenter).to receive(:new).with(delivery_organisation, group_by: Metrics::GroupBy::Service, order: 'asc', order_by: 'name') { presenter }
+      expect(MetricsPresenter).to receive(:new).with(delivery_organisation, group_by: Metrics::GroupBy::Service, order: 'asc', order_by: 'name', time_period: TimePeriod.default) { presenter }
 
       get :index, params: { delivery_organisation_id: '1923', group_by: Metrics::GroupBy::Service, filter: { order: 'asc', order_by: 'name' } }
       expect(assigns[:metrics]).to eq(presenter)

--- a/spec/controllers/view_data/department_metrics_controller_spec.rb
+++ b/spec/controllers/view_data/department_metrics_controller_spec.rb
@@ -16,10 +16,11 @@ RSpec.describe ViewData::DepartmentMetricsController, type: :controller do
     end
 
     it 'assigns a DepartmentMetrics presenter to @metrics' do
+      default_time_period = TimePeriod.default
       presenter = instance_double(MetricsPresenter)
-      expect(MetricsPresenter).to receive(:new).with(department, group_by: Metrics::GroupBy::DeliveryOrganisation, order: 'asc', order_by: 'name') { presenter }
+      expect(MetricsPresenter).to receive(:new).with(department, group_by: Metrics::GroupBy::DeliveryOrganisation, order: 'asc', order_by: 'name', time_period: default_time_period) { presenter }
 
-      get :index, params: { department_id: 'D001', group_by: Metrics::GroupBy::DeliveryOrganisation, filter: { order: 'asc', order_by: 'name' } }
+      get :index, params: { department_id: 'D001', group_by: Metrics::GroupBy::DeliveryOrganisation, filter: { order: 'asc', order_by: 'name', time_period: default_time_period } }
       expect(assigns[:metrics]).to eq(presenter)
     end
 

--- a/spec/controllers/view_data/government_metrics_controller_spec.rb
+++ b/spec/controllers/view_data/government_metrics_controller_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe ViewData::GovernmentMetricsController, type: :controller do
 
     it 'assigns a GovernmentMetrics presenter to @metrics' do
       presenter = instance_double(MetricsPresenter)
-      expect(MetricsPresenter).to receive(:new).with(government, group_by: Metrics::GroupBy::Department, order: 'asc', order_by: 'name') { presenter }
+      expect(MetricsPresenter).to receive(:new).with(government, group_by: Metrics::GroupBy::Department, order: 'asc', order_by: 'name', time_period: TimePeriod.default) { presenter }
 
       get :index, params: { group_by: Metrics::GroupBy::Department, filter: { order: 'asc', order_by: 'name' } }
       expect(assigns[:metrics]).to eq(presenter)

--- a/spec/models/time_period_spec.rb
+++ b/spec/models/time_period_spec.rb
@@ -38,6 +38,39 @@ RSpec.describe TimePeriod, type: :model do
     end
   end
 
+  describe '#serialise' do
+    it 'can serialise objects' do
+      period = TimePeriod.new(Date.new(2017, 1, 1), Date.new(2017, 3, 30))
+      serialised = TimePeriod.serialise(period)
+      expect(serialised).to eq("2017-01-01 2017-03-30")
+    end
+  end
+
+  describe '#deserialise' do
+    it 'can deserialise objects' do
+      period = TimePeriod.new(Date.new(2017, 1, 1), Date.new(2017, 3, 30))
+      new_period = TimePeriod.deserialise("2017-01-01 2017-03-30")
+      expect(period.starts_on).to eq(new_period.starts_on)
+      expect(period.ends_on).to eq(new_period.ends_on)
+    end
+
+    it 'can ignore bad input data when deserialising' do
+      period = TimePeriod.deserialise("Not dates")
+      expect(period).to be_nil
+    end
+  end
+
+  describe 'serialisation roundtrip' do
+    it 'can serialise and deserialise objects' do
+      period = TimePeriod.new(Date.new(2017, 1, 1), Date.new(2017, 3, 30))
+      serialised = TimePeriod.serialise(period)
+      new_period = TimePeriod.deserialise(serialised)
+      expect(period.starts_on).to eq(new_period.starts_on)
+      expect(period.ends_on).to eq(new_period.ends_on)
+    end
+  end
+
+
   describe '#previous_period' do
     it 'can return the previous period for short periods' do
       period = TimePeriod.new(Date.new(2017, 1, 1), Date.new(2017, 3, 30))


### PR DESCRIPTION
Adds two class methods to TimePeriod, one to convert it to a string (for storage)
and one to convert a string back into a TimePeriod.

Changes the controllers to get the time period either from the session or to use
the default. Fixes tests and adds an equality operator to time_period, we think they
are the same if the dates match, rather than the object identity.

