### PR TITLE
Fix the department count when viewing at Government level.

### DIFF
--- a/app/models/department.rb
+++ b/app/models/department.rb
@@ -9,7 +9,9 @@ class Department < ApplicationRecord
   validates_presence_of :website, strict: true
 
   def self.with_delivery_organisations
-    self.joins(:services).distinct
+    # Only delivery organisations that have at least 1
+    # service with published data.
+    self.joins(:services).merge(Service.with_published_metrics).distinct
   end
 
   def to_param

--- a/app/models/department.rb
+++ b/app/models/department.rb
@@ -9,8 +9,8 @@ class Department < ApplicationRecord
   validates_presence_of :website, strict: true
 
   def self.with_delivery_organisations
-    # Only delivery organisations that have at least 1
-    # service with published data.
+    # Only return departments where at least one of its services
+    # contains a published metric.
     self.joins(:services).merge(Service.with_published_metrics).distinct
   end
 

--- a/spec/models/government_spec.rb
+++ b/spec/models/government_spec.rb
@@ -4,7 +4,49 @@ RSpec.describe Government, type: :model do
   subject(:government) { Government.new }
 
   describe '#departments_count' do
-    it 'returns the total number of departments' do
+    it 'returns the total number of departments where 1 service has published data' do
+      d1 = FactoryGirl.create(:department, name: "test 1")
+      d2 = FactoryGirl.create(:department, name: "test 2")
+      d3 = FactoryGirl.create(:department, name: "test 3")
+
+      do1 = FactoryGirl.create(:delivery_organisation, name: "do test 1", department: d1)
+      do2 = FactoryGirl.create(:delivery_organisation, name: "do test 2", department: d2)
+      do3 = FactoryGirl.create(:delivery_organisation, name: "do test 3", department: d3)
+
+      s = FactoryGirl.create(:service, name: "service test 1", delivery_organisation: do1)
+      FactoryGirl.create(:service, name: "service test 2", delivery_organisation: do2)
+      FactoryGirl.create(:service, name: "service test 3", delivery_organisation: do3)
+
+      FactoryGirl.create(:monthly_service_metrics, service: s, month: "2017-01-01", published: true)
+
+      expect(government.departments_count).to eq(1)
+    end
+  end
+
+  describe '#departments_count' do
+    it 'returns the total number of departments where all services have published data' do
+      d1 = FactoryGirl.create(:department, name: "test 1")
+      d2 = FactoryGirl.create(:department, name: "test 2")
+      d3 = FactoryGirl.create(:department, name: "test 3")
+
+      do1 = FactoryGirl.create(:delivery_organisation, name: "do test 1", department: d1)
+      do2 = FactoryGirl.create(:delivery_organisation, name: "do test 2", department: d2)
+      do3 = FactoryGirl.create(:delivery_organisation, name: "do test 3", department: d3)
+
+      s1 = FactoryGirl.create(:service, name: "service test 1", delivery_organisation: do1)
+      s2 = FactoryGirl.create(:service, name: "service test 2", delivery_organisation: do2)
+      s3 = FactoryGirl.create(:service, name: "service test 3", delivery_organisation: do3)
+
+      FactoryGirl.create(:monthly_service_metrics, service: s1, month: "2017-01-01", published: true)
+      FactoryGirl.create(:monthly_service_metrics, service: s2, month: "2017-01-01", published: true)
+      FactoryGirl.create(:monthly_service_metrics, service: s3, month: "2017-01-01", published: true)
+
+      expect(government.departments_count).to eq(3)
+    end
+  end
+
+  describe '#departments_count' do
+    it 'returns the total number of departments where no services have published data' do
       d1 = FactoryGirl.create(:department, name: "test 1")
       d2 = FactoryGirl.create(:department, name: "test 2")
       d3 = FactoryGirl.create(:department, name: "test 3")
@@ -17,7 +59,7 @@ RSpec.describe Government, type: :model do
       FactoryGirl.create(:service, name: "service test 2", delivery_organisation: do2)
       FactoryGirl.create(:service, name: "service test 3", delivery_organisation: do3)
 
-      expect(government.departments_count).to eq(3)
+      expect(government.departments_count).to eq(0)
     end
   end
 


### PR DESCRIPTION
When we are looking at government aggregated data, we show the number of
departments, and originally this was just departments that have a
delivery organisation. This didn't take account any delivery
organisations that had no services, or no services with published data.

This PR changes the determination of department count to take into
account only those departments with delivery organisations with services
with published data.

The delivery organisations count, and the services count were already
correct.

This raises the issue of what we do with a custom time period.  Do we
only show departments with published data __within__ that time period?
Or do we show them all but it'll show up as no data?