### PR TITLE
Allow services to be marked as having sampled call data

### DIFF
--- a/app/admin/service.rb
+++ b/app/admin/service.rb
@@ -10,7 +10,7 @@ ActiveAdmin.register Service do
     column :name
     column :delivery_organisation
     column :department
-    column "Missing context" do |s|
+    column "Context?" do |s|
       status_tag("Missing", class: "error") if [s.purpose, s.how_it_works, s.typical_users, s.start_page_url].any?(&:blank?)
     end
     actions
@@ -33,6 +33,7 @@ ActiveAdmin.register Service do
       row "Label for other calls field" do |service|
         service.calls_other_name || ""
       end
+      row("Are calls sampled?", &:sampled_calls)
     end
 
     attributes_table title: "Contextual information" do
@@ -134,6 +135,8 @@ ActiveAdmin.register Service do
       f.input :calls_received_challenge_decision_applicable
       f.input :calls_received_other_applicable
       f.input :calls_received_perform_transaction_applicable
+      br
+      f.input :sampled_calls
     end
     actions
   end
@@ -166,7 +169,7 @@ ActiveAdmin.register Service do
                 :calls_received_applicable, :calls_received_get_information_applicable,
                 :calls_received_chase_progress_applicable, :calls_received_challenge_decision_applicable,
                 :calls_received_other_applicable, :calls_received_perform_transaction_applicable,
-                :other_name, :calls_other_name
+                :other_name, :calls_other_name, :sampled_calls
 
   remove_filter :online_transactions_applicable, :phone_transactions_applicable,
                 :paper_transactions_applicable,  :face_to_face_transactions_applicable,

--- a/app/models/calls_received_metric.rb
+++ b/app/models/calls_received_metric.rb
@@ -10,10 +10,6 @@ class CallsReceivedMetric < Metric
     percentage_of :total
   end
 
-  def sampled
-    false
-  end
-
   def sampled_total
     total
   end

--- a/app/models/monthly_service_metrics.rb
+++ b/app/models/monthly_service_metrics.rb
@@ -22,7 +22,7 @@ class MonthlyServiceMetrics < ApplicationRecord
     end
 
     def calls_received_metric
-      @calls_received_metric ||= CallsReceivedMetric.from_metrics(self)
+      @calls_received_metric ||= CallsReceivedMetric.from_metrics(self, with_samples: true)
     end
   end
 
@@ -71,6 +71,6 @@ class MonthlyServiceMetrics < ApplicationRecord
   end
 
   def calls_received_metric
-    @calls_received_metric ||= CallsReceivedMetric.from_metrics(self)
+    @calls_received_metric ||= CallsReceivedMetric.from_metrics(self, with_samples: true)
   end
 end

--- a/db/migrate/20180123133950_add_sample_field_to_service.rb
+++ b/db/migrate/20180123133950_add_sample_field_to_service.rb
@@ -1,0 +1,5 @@
+class AddSampleFieldToService < ActiveRecord::Migration[5.1]
+  def change
+    add_column :services, :sampled_calls, :boolean, null: false, default: false    
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171227101246) do
+ActiveRecord::Schema.define(version: 20180123133950) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -118,6 +118,7 @@ ActiveRecord::Schema.define(version: 20171227101246) do
     t.integer "owner_id"
     t.text "calls_other_name"
     t.text "other_name"
+    t.boolean "sampled_calls", default: false, null: false
     t.index ["natural_key"], name: "index_services_on_natural_key", unique: true
     t.index ["publish_token"], name: "index_services_on_publish_token", unique: true
   end


### PR DESCRIPTION
This PR adds a new field to the service to denote whether the
call data is sampled or not.  This can be set in admin.

Unfortunately getting that flag to the template is not so straight
forward and so the changes in app/models/metric.rb are not ideal.