### PR TITLE
Add explanatory text to 'perform a transaction' when publishing.

### DIFF
--- a/app/helpers/form_helper.rb
+++ b/app/helpers/form_helper.rb
@@ -9,14 +9,23 @@ module FormHelper
       end
     end
 
-    def metric(name, applicable: true, label: nil)
+    def metric(name, applicable: true, label: nil, extra: nil)
       return '' unless applicable
 
-      lbl = label || I18n.translate(name, scope: %w(helpers label monthly_service_metrics))
+      label = label || I18n.translate(name, scope: %w(helpers label monthly_service_metrics))
 
       @template.content_tag(:div, class: 'form-group') do
-        label(name, lbl, class: 'form-label') + number_field(name, class: 'form-control form-control-1-4')
+        content = label(name, label.capitalize, class: 'form-label')
+        field_content = number_field(name, class: 'form-control form-control-1-4')
+
+        if extra
+          content += @template.content_tag(:span, extra, class: "form-hint")
+        end
+        content += field_content
+        content
       end
+
+
     end
   end
 end

--- a/app/helpers/form_helper.rb
+++ b/app/helpers/form_helper.rb
@@ -24,8 +24,6 @@ module FormHelper
         content += field_content
         content
       end
-
-
     end
   end
 end

--- a/app/views/publish_data/monthly_service_metrics/edit.html.erb
+++ b/app/views/publish_data/monthly_service_metrics/edit.html.erb
@@ -53,7 +53,7 @@
         <% end %>
 
         <%= f.fieldset 'Number of phone calls received, split by reasons for calling' do %>
-          <%= f.metric :calls_received_perform_transaction, applicable: @monthly_service_metrics.service.calls_received_perform_transaction_applicable %>
+          <%= f.metric :calls_received_perform_transaction, applicable: @monthly_service_metrics.service.calls_received_perform_transaction_applicable, extra: "This value should be the same as the number of transactions received by phone" %>
           <%= f.metric :calls_received_get_information, applicable: @monthly_service_metrics.service.calls_received_get_information_applicable %>
           <%= f.metric :calls_received_chase_progress, applicable: @monthly_service_metrics.service.calls_received_chase_progress_applicable %>
           <%= f.metric :calls_received_challenge_decision, applicable: @monthly_service_metrics.service.calls_received_challenge_decision_applicable %>

--- a/spec/features/submitting_monthly_service_metrics_spec.rb
+++ b/spec/features/submitting_monthly_service_metrics_spec.rb
@@ -31,10 +31,10 @@ RSpec.feature 'submitting monthly service metrics' do
     end
 
     within_fieldset('Number of phone calls received, split by reasons for calling') do
-      fill_in 'to perform a transaction', with: '6,000'
-      fill_in 'to get information', with: '10,000'
-      fill_in 'to chase progress', with: '9,000'
-      fill_in 'to challenge a decision', with: '8,000'
+      fill_in 'To perform a transaction', with: '6,000'
+      fill_in 'To get information', with: '10,000'
+      fill_in 'To chase progress', with: '9,000'
+      fill_in 'To challenge a decision', with: '8,000'
       fill_in 'Number of telephone calls for this reason', with: '7,000'
     end
 


### PR DESCRIPTION
On the publishing page, we've added a form-hint to the input for 'to
perform a transaction' to make it clear that it should be the same
value as Transactions received by phone.