### PR TITLE
Makes a previous time periods worth of data available

### DIFF
--- a/app/assets/stylesheets/__base.scss
+++ b/app/assets/stylesheets/__base.scss
@@ -52,6 +52,10 @@ fieldset > h2 {
     th { font-size: 16px; }
 }
 
+.detail-context {
+    margin-top: 20px;
+}
+
 @import "breadcrumbs";
 @import "homepage";
 @import "metadata";

--- a/app/assets/stylesheets/_metadata.scss
+++ b/app/assets/stylesheets/_metadata.scss
@@ -2,6 +2,7 @@
   @extend %contain-floats;
 
   font-size: 16px;
+  margin-top: 20px;
 
   dt {
     float: left;

--- a/app/assets/stylesheets/_metric_group.scss
+++ b/app/assets/stylesheets/_metric_group.scss
@@ -141,10 +141,6 @@ span.not-provided-message {
   background-color: #EFF0F1;
 }
 
-.m-time-period-selector {
-  margin-bottom: $gutter;
-}
-
 .m-metric-group__preview {
   .metric-value-not-provided,
   .not-provided,

--- a/app/assets/stylesheets/_service.scss
+++ b/app/assets/stylesheets/_service.scss
@@ -2,6 +2,15 @@
 .service-context {
     ul {
         list-style-type: disc;
+        padding-left: 20px;
+    }
+    ul.list {
+        padding-left: 0;
+    }
+
+    h2 {
+      margin-bottom: 0;
+      margin-top: 25px;
     }
 }
 

--- a/app/controllers/view_data/delivery_organisations_controller.rb
+++ b/app/controllers/view_data/delivery_organisations_controller.rb
@@ -4,6 +4,7 @@ module ViewData
       @delivery_organisation = DeliveryOrganisation.where(natural_key: params[:id]).first!
 
       @metrics = MetricsPresenter.new(@delivery_organisation, group_by: Metrics::GroupBy::DeliveryOrganisation, time_period: time_period)
+      @previous = MetricsPresenter.new(@delivery_organisation, group_by: Metrics::GroupBy::DeliveryOrganisation, time_period: time_period.previous_period)
 
       page.title = @delivery_organisation.name
 

--- a/app/controllers/view_data/delivery_organisations_controller.rb
+++ b/app/controllers/view_data/delivery_organisations_controller.rb
@@ -6,11 +6,10 @@ module ViewData
       @metrics = MetricsPresenter.new(@delivery_organisation, group_by: Metrics::GroupBy::DeliveryOrganisation, time_period: time_period)
       @previous = MetricsPresenter.new(@delivery_organisation, group_by: Metrics::GroupBy::DeliveryOrganisation, time_period: time_period.previous_period)
 
-      page.title = @delivery_organisation.name
+      @current_by_metrics = @metrics.metric_groups.last.sorted_metrics_by_month
+      @previous_by_metrics = @previous.metric_groups.last.sorted_metrics_by_month
 
-      page.breadcrumbs << Page::Crumb.new('UK Government', view_data_government_metrics_path)
-      page.breadcrumbs << Page::Crumb.new(@delivery_organisation.department.name, view_data_department_path(id: @delivery_organisation.department))
-      page.breadcrumbs << Page::Crumb.new(@delivery_organisation.name)
+      page.title = @delivery_organisation.name
 
       respond_to do |format|
         format.html

--- a/app/controllers/view_data/departments_controller.rb
+++ b/app/controllers/view_data/departments_controller.rb
@@ -4,6 +4,7 @@ module ViewData
       @department = Department.where(natural_key: params[:id]).first!
 
       @metrics = MetricsPresenter.new(@department, group_by: Metrics::GroupBy::Department, time_period: time_period)
+      @previous = MetricsPresenter.new(@department, group_by: Metrics::GroupBy::Department, time_period: time_period.previous_period)
 
       page.title = @department.name
 

--- a/app/controllers/view_data/departments_controller.rb
+++ b/app/controllers/view_data/departments_controller.rb
@@ -6,10 +6,10 @@ module ViewData
       @metrics = MetricsPresenter.new(@department, group_by: Metrics::GroupBy::Department, time_period: time_period)
       @previous = MetricsPresenter.new(@department, group_by: Metrics::GroupBy::Department, time_period: time_period.previous_period)
 
-      page.title = @department.name
+      @current_by_metrics = @metrics.metric_groups.last.sorted_metrics_by_month
+      @previous_by_metrics = @previous.metric_groups.last.sorted_metrics_by_month
 
-      page.breadcrumbs << Page::Crumb.new('UK Government', view_data_government_metrics_path)
-      page.breadcrumbs << Page::Crumb.new(@department.name)
+      page.title = @department.name
 
       respond_to do |format|
         format.html

--- a/app/controllers/view_data/services_controller.rb
+++ b/app/controllers/view_data/services_controller.rb
@@ -7,7 +7,6 @@ module ViewData
       @previous = MetricsPresenter.new(@service, group_by: Metrics::GroupBy::Service, time_period: time_period.previous_period)
 
       page.title = @service.name
-
       page.breadcrumbs << Page::Crumb.new('UK Government', view_data_government_metrics_path)
       page.breadcrumbs << Page::Crumb.new(@service.department.name, view_data_department_metrics_path(department_id: @service.department))
 

--- a/app/controllers/view_data/services_controller.rb
+++ b/app/controllers/view_data/services_controller.rb
@@ -4,6 +4,7 @@ module ViewData
       @service = Service.where(natural_key: params[:id]).first!
 
       @metrics = MetricsPresenter.new(@service, group_by: Metrics::GroupBy::Service, time_period: time_period)
+      @previous = MetricsPresenter.new(@service, group_by: Metrics::GroupBy::Service, time_period: time_period.previous_period)
 
       page.title = @service.name
 

--- a/app/helpers/details_helper.rb
+++ b/app/helpers/details_helper.rb
@@ -1,0 +1,50 @@
+module DetailsHelper
+  def trxn_rx_metrics
+    %w(total online phone paper face_to_face other)
+  end
+
+  def trxn_proc_metrics
+    %w(total with_intended_outcome)
+  end
+
+  def calls_rx_metrics
+    %w(total perform_transaction get_information chase_progress challenge_a_decision other)
+  end
+
+  def trxn_rx_metric_label(m)
+    I18n.translate(m, scope: %w(helpers missing TransactionsReceivedMetric))
+  end
+
+  def trxn_proc_metric_label(m)
+    I18n.translate(m, scope: %w(helpers missing TransactionsProcessedMetric))
+  end
+
+  def calls_metric_label(m)
+    I18n.translate(m, scope: %w(helpers missing CallsReceivedMetric))
+  end
+
+  def received_not_applicable?(svc)
+    [
+      svc.online_transactions_applicable,
+      svc.phone_transactions_applicable,
+      svc.paper_transactions_applicable,
+      svc.face_to_face_transactions_applicable,
+      svc.other_transactions_applicable
+    ].none?
+  end
+
+  def processed_not_applicable?(svc)
+    [svc.transactions_processed_applicable, svc.transactions_processed_with_intended_outcome_applicable].none?
+  end
+
+  def calls_not_applicable?(svc)
+    [
+      svc.calls_received_applicable,
+      svc.calls_received_get_information_applicable,
+      svc.calls_received_chase_progress_applicable,
+      svc.calls_received_challenge_decision_applicable,
+      svc.calls_received_other_applicable,
+      svc.calls_received_perform_transaction_applicable
+    ].none?
+  end
+end

--- a/app/views/view_data/_calls_received_section.html.erb
+++ b/app/views/view_data/_calls_received_section.html.erb
@@ -1,0 +1,17 @@
+<div class="grid-row">
+  <div class="column-two-thirds">
+    <h1 class="heading-large">Phone calls received</h1>
+    <p>
+      These numbers tell you how much call centres were used, and why.
+    </p>
+    <p>
+      If the total number of calls is higher than the number of transactions, that’s an indication that effort is high compared to output.
+    </p>
+    <p>
+      If the proportion of users calling to chase progress is high, this might mean that the organisation isn’t processing transactions as quickly as they should. A high proportion of calls to get more information could indicate that information available online is incomplete or unclear.
+    </p>
+    <p>
+      <a href="">See a detailed description of how phone calls received is defined.</a>
+    </p>
+  </div>
+</div>

--- a/app/views/view_data/_transactions_processed_section.html.erb
+++ b/app/views/view_data/_transactions_processed_section.html.erb
@@ -1,0 +1,11 @@
+<div class="grid-row">
+  <div class="column-two-thirds">
+    <h1 class="heading-large">Transactions processed</h1>
+    <p>
+      These numbers tell you how many transactions were processed by the organisation, and how well these transactions met users' needs.
+    </p>
+    <p>
+      <a href="">See a detailed description of how transactions processed is defined.</a>
+    </p>
+  </div>
+</div>

--- a/app/views/view_data/_transactions_received_section.html.erb
+++ b/app/views/view_data/_transactions_received_section.html.erb
@@ -1,0 +1,11 @@
+<div class="grid-row">
+  <div class="column-two-thirds">
+    <h1 class="heading-large">Transactions received</h1>
+    <p>
+      These numbers tell you how much the organisation was used, and which channels were used the most.
+    </p>
+    <p>
+      <a href="">See a detailed description of how transactions received is defined.</a>
+    </p>
+  </div>
+</div>

--- a/app/views/view_data/delivery_organisations/show.html.erb
+++ b/app/views/view_data/delivery_organisations/show.html.erb
@@ -33,50 +33,14 @@
     </div>
   </div>
 
-
-  <div class="grid-row">
-    <div class="column-two-thirds">
-      <h1 class="heading-large">Transactions received</h1>
-      <p>
-        These numbers tell you how much the organisation was used, and which channels were used the most.
-      </p>
-      <p>
-        <a href="">See a detailed description of how transactions received is defined.</a>
-      </p>
-    </div>
-  </div>
+  <%= render partial: "view_data/transactions_received_section" %>
 
   <hr/>
 
-  <div class="grid-row">
-    <div class="column-two-thirds">
-      <h1 class="heading-large">Transactions processed</h1>
-      <p>
-        These numbers tell you how many transactions were processed by the organisation, and how well these transactions met users' needs.
-      </p>
-      <p>
-        <a href="">See a detailed description of how transactions processed is defined.</a>
-      </p>
-    </div>
-  </div>
+  <%= render partial: "view_data/transactions_processed_section" %>
 
   <hr/>
 
-  <div class="grid-row">
-    <div class="column-two-thirds">
-      <h1 class="heading-large">Phone calls received</h1>
-      <p>
-        These numbers tell you how much call centres were used, and why.
-      </p>
-      <p>
-        If the total number of calls is higher than the number of transactions, that’s an indication that effort is high compared to output.
-      </p>
-      <p>
-        If the proportion of users calling to chase progress is high, this might mean that the organisation isn’t processing transactions as quickly as they should. A high proportion of calls to get more information could indicate that information available online is incomplete or unclear.
-      </p>
-      <p>
-        <a href="">See a detailed description of how phone calls received is defined.</a>
-      </p>
-    </div>
-  </div>
+  <%= render partial: "view_data/calls_received_section" %>
+
 </main>

--- a/app/views/view_data/delivery_organisations/show.html.erb
+++ b/app/views/view_data/delivery_organisations/show.html.erb
@@ -1,6 +1,6 @@
 <main id="content" role="main">
 
-  <%= breadcrumbs %>
+  <a class="link-back" href="<%= view_data_delivery_organisation_metrics_path(@delivery_organisation) %>">Back to <%= @delivery_organisation.name %> list view</a>
 
   <div class="grid-row">
     <div class="column-two-thirds">
@@ -21,41 +21,62 @@
   </div>
 
   <div class="grid-row">
+    <div class="column-two-thirds detail-context">
+      <ul class="list list-bullet">
+        <li>
+          <%= render 'view_data/metrics/time_period_selector', time_period: @metrics.time_period %>
+        </li>
+        <li>
+          This data is aggregated from <a href="<%= view_data_delivery_organisation_metrics_path delivery_organisation_id: @delivery_organisation.natural_key,group_by: Metrics::GroupBy::Service %>"><%= pluralize(@delivery_organisation.services_count, 'service')%></a>
+        </li>
+      </ul>
+    </div>
+  </div>
 
-    <div class="column-two-thirds department-context">
 
-      <h1 class="heading-medium">Data about this delivery organisation</h1>
-
-      <p class="lede">
-        Showing data for the year from  <%= time_tag @metrics.time_period.starts_on, @metrics.time_period.starts_on.to_formatted_s(:abbreviated_day_month_year) %> to <%= time_tag @metrics.time_period.ends_on, @metrics.time_period.ends_on.to_formatted_s(:abbreviated_day_month_year) %>
+  <div class="grid-row">
+    <div class="column-two-thirds">
+      <h1 class="heading-large">Transactions received</h1>
+      <p>
+        These numbers tell you how much the organisation was used, and which channels were used the most.
       </p>
-
-      <p class="lede">
-        Data is aggregated from <a href="<%= view_data_delivery_organisation_metrics_path delivery_organisation_id: @delivery_organisation.natural_key,group_by: Metrics::GroupBy::Service %>"><%= pluralize(@delivery_organisation.services_count, 'service')%></a></a>
+      <p>
+        <a href="">See a detailed description of how transactions received is defined.</a>
       </p>
-
     </div>
   </div>
 
   <hr/>
 
   <div class="grid-row">
-    <div class="column-full">
-      <h1 class="heading-medium">Delivery organisation data</h1>
+    <div class="column-two-thirds">
+      <h1 class="heading-large">Transactions processed</h1>
+      <p>
+        These numbers tell you how many transactions were processed by the organisation, and how well these transactions met users' needs.
+      </p>
+      <p>
+        <a href="">See a detailed description of how transactions processed is defined.</a>
+      </p>
+    </div>
+  </div>
 
-      <div class='m-metric-group'>
-        <div>
-          <div class='completeness service-context-completeness'>
-            <a href="<%= @metrics.metric_groups.last.entity.missing_data_link %>">
-                <%= @metrics.metric_groups.last.completeness %> of data provided
-            </a>
-          </div>
+  <hr/>
 
-          <div class="m-metrics">
-            <%= render @metrics.metric_groups.last.metrics, metric_group: @metrics.metric_groups.last%>
-          </div>
-        </div>
-      </div>
+  <div class="grid-row">
+    <div class="column-two-thirds">
+      <h1 class="heading-large">Phone calls received</h1>
+      <p>
+        These numbers tell you how much call centres were used, and why.
+      </p>
+      <p>
+        If the total number of calls is higher than the number of transactions, that’s an indication that effort is high compared to output.
+      </p>
+      <p>
+        If the proportion of users calling to chase progress is high, this might mean that the organisation isn’t processing transactions as quickly as they should. A high proportion of calls to get more information could indicate that information available online is incomplete or unclear.
+      </p>
+      <p>
+        <a href="">See a detailed description of how phone calls received is defined.</a>
+      </p>
     </div>
   </div>
 </main>

--- a/app/views/view_data/departments/show.html.erb
+++ b/app/views/view_data/departments/show.html.erb
@@ -33,50 +33,14 @@
     </div>
   </div>
 
-
-  <div class="grid-row">
-    <div class="column-two-thirds">
-      <h1 class="heading-large">Transactions received</h1>
-      <p>
-        These numbers tell you how much the organisation was used, and which channels were used the most.
-      </p>
-      <p>
-        <a href="">See a detailed description of how transactions received is defined.</a>
-      </p>
-    </div>
-  </div>
+  <%= render partial: "view_data/transactions_received_section" %>
 
   <hr/>
 
-  <div class="grid-row">
-    <div class="column-two-thirds">
-      <h1 class="heading-large">Transactions processed</h1>
-      <p>
-        These numbers tell you how many transactions were processed by the organisation, and how well these transactions met users' needs.
-      </p>
-      <p>
-        <a href="">See a detailed description of how transactions processed is defined.</a>
-      </p>
-    </div>
-  </div>
+  <%= render partial: "view_data/transactions_processed_section" %>
 
   <hr/>
 
-  <div class="grid-row">
-    <div class="column-two-thirds">
-      <h1 class="heading-large">Phone calls received</h1>
-      <p>
-        These numbers tell you how much call centres were used, and why.
-      </p>
-      <p>
-        If the total number of calls is higher than the number of transactions, that’s an indication that effort is high compared to output.
-      </p>
-      <p>
-        If the proportion of users calling to chase progress is high, this might mean that the organisation isn’t processing transactions as quickly as they should. A high proportion of calls to get more information could indicate that information available online is incomplete or unclear.
-      </p>
-      <p>
-        <a href="">See a detailed description of how phone calls received is defined.</a>
-      </p>
-    </div>
-  </div>
+  <%= render partial: "view_data/calls_received_section" %>
+
 </main>

--- a/app/views/view_data/departments/show.html.erb
+++ b/app/views/view_data/departments/show.html.erb
@@ -1,6 +1,6 @@
 <main id="content" role="main">
 
-  <%= breadcrumbs %>
+  <a class="link-back" href="<%= view_data_department_metrics_path(@department) %>">Back to <%= @department.name %> list view</a>
 
   <div class="grid-row">
     <div class="column-two-thirds">
@@ -21,14 +21,27 @@
   </div>
 
   <div class="grid-row">
-    <div class="column-two-thirds department-context">
-      <h1 class="heading-medium">Data about this organisation</h1>
-      <p class="lede">
-        Showing data for the year from  <%= time_tag @metrics.time_period.starts_on, @metrics.time_period.starts_on.to_formatted_s(:abbreviated_day_month_year) %> to <%= time_tag @metrics.time_period.ends_on, @metrics.time_period.ends_on.to_formatted_s(:abbreviated_day_month_year) %>
-      </p>
+    <div class="column-two-thirds detail-context">
+      <ul class="list list-bullet">
+        <li>
+          <%= render 'view_data/metrics/time_period_selector', time_period: @metrics.time_period %>
+        </li>
+        <li>
+          This data is aggregated from <a href="<%= view_data_department_metrics_path department_id: @department.natural_key,group_by: Metrics::GroupBy::Service %>"><%= pluralize(@department.services_count, 'service')%></a>
+        </li>
+      </ul>
+    </div>
+  </div>
 
-      <p class="lede">
-        Data is aggregated from <a href="<%= view_data_department_metrics_path department_id: @department.natural_key,group_by: Metrics::GroupBy::Service %>"><%= pluralize(@department.services_count, 'service')%></a> in <a href="<%= view_data_department_metrics_path department_id: @department.natural_key,group_by: Metrics::GroupBy::DeliveryOrganisation %>"><%= pluralize(@department.delivery_organisations_count, 'delivery organisation')%></a>
+
+  <div class="grid-row">
+    <div class="column-two-thirds">
+      <h1 class="heading-large">Transactions received</h1>
+      <p>
+        These numbers tell you how much the organisation was used, and which channels were used the most.
+      </p>
+      <p>
+        <a href="">See a detailed description of how transactions received is defined.</a>
       </p>
     </div>
   </div>
@@ -36,23 +49,34 @@
   <hr/>
 
   <div class="grid-row">
-    <div class="column-full">
-      <h1 class="heading-medium">Department data</h1>
+    <div class="column-two-thirds">
+      <h1 class="heading-large">Transactions processed</h1>
+      <p>
+        These numbers tell you how many transactions were processed by the organisation, and how well these transactions met users' needs.
+      </p>
+      <p>
+        <a href="">See a detailed description of how transactions processed is defined.</a>
+      </p>
+    </div>
+  </div>
 
-      <div class='m-metric-group'>
-        <div>
-          <div class='completeness service-context-completeness'>
-            <a href="<%= @metrics.metric_groups.last.entity.missing_data_link %>">
-              <%= @metrics.metric_groups.last.completeness %> of data provided
-            </a>
+  <hr/>
 
-          </div>
-
-          <div class="m-metrics">
-            <%= render @metrics.metric_groups.last.metrics, metric_group: @metrics.metric_groups.last%>
-          </div>
-        </div>
-      </div>
+  <div class="grid-row">
+    <div class="column-two-thirds">
+      <h1 class="heading-large">Phone calls received</h1>
+      <p>
+        These numbers tell you how much call centres were used, and why.
+      </p>
+      <p>
+        If the total number of calls is higher than the number of transactions, that’s an indication that effort is high compared to output.
+      </p>
+      <p>
+        If the proportion of users calling to chase progress is high, this might mean that the organisation isn’t processing transactions as quickly as they should. A high proportion of calls to get more information could indicate that information available online is incomplete or unclear.
+      </p>
+      <p>
+        <a href="">See a detailed description of how phone calls received is defined.</a>
+      </p>
     </div>
   </div>
 </main>

--- a/app/views/view_data/metrics/_time_period_selector.html.erb
+++ b/app/views/view_data/metrics/_time_period_selector.html.erb
@@ -1,5 +1,5 @@
 <div class="m-time-period-selector">
-  Showing data for time period from <%= time_tag time_period.starts_on, time_period.starts_on.to_formatted_s(:abbreviated_day_month_year) %> to <%= time_tag time_period.ends_on, time_period.ends_on.to_formatted_s(:abbreviated_day_month_year) %>.
+  Showing data for time period from <%= time_tag time_period.starts_on, time_period.starts_on.to_formatted_s(:month_and_year) %> to <%= time_tag time_period.ends_on, time_period.ends_on.to_formatted_s(:month_and_year) %>.
   <br/>
   <%= link_to "Change time period", view_data_time_period_path %>
 </div>

--- a/app/views/view_data/metrics/index.html.erb
+++ b/app/views/view_data/metrics/index.html.erb
@@ -1,5 +1,5 @@
 <main id="content" role="main" class="metrics">
-  <%= breadcrumbs %>
+
 
   <header class="grid-row">
     <div class="column-two-thirds">
@@ -22,7 +22,7 @@
   </header>
 
   <div class="grid-row">
-    <div class="column-full">
+    <div class="column-full" style="margin-top: 20px;">
 
       <%= tabs(current_page: page) do |tabs| %>
         <% tabs.link_to tab_name('Departments', count: @metrics.departments_count), url_for(request.params.merge(group_by: Metrics::GroupBy::Department)) if @metrics.has_departments? %>

--- a/app/views/view_data/metrics/index.html.erb
+++ b/app/views/view_data/metrics/index.html.erb
@@ -1,6 +1,5 @@
 <main id="content" role="main" class="metrics">
 
-
   <header class="grid-row">
     <div class="column-two-thirds">
       <h1 class="heading-xlarge small-top-margin">

--- a/app/views/view_data/services/show.html.erb
+++ b/app/views/view_data/services/show.html.erb
@@ -12,8 +12,6 @@
       <dl class="metadata">
         <dt>Data provider:</dt>
         <dd><%= @service.department.name %></dd>
-        <dt>Collection method:</dt>
-        <dd>Manual upload via spreadsheet</dd>
         <dt>Last updated:</dt>
         <dd>
           <!-- TODO: This should be the most recent metric date -->
@@ -51,50 +49,88 @@
       <h2 class="heading-medium">Users</h2>
       <%= render_markdown(@service.typical_users) %>
 
-         </div>
-
-    <div class="column-one-third">
       <h2 class="heading-medium">Visit the service</h2>
-      <p>See how it appears to users:</p>
-        <ul class="list">
-          <% if @service.start_page_url.present? %>
-            <li><%= link_to 'Start page', @service.start_page_url %></li>
-          <% end %>
+      <ul class="list" style="list-style: none;">
+        <% if @service.start_page_url.present? %>
+          <li><%= link_to 'Start page', @service.start_page_url %></li>
+        <% end %>
 
-          <% if @service.paper_form_url.present? %>
-            <li><%= link_to 'Paper form', @service.paper_form_url %></li>
-            <!-- <li>This service is delivered by <%= link_to %></li> -->
-          <% end %>
-        </ul>
-    </div>
+        <% if @service.paper_form_url.present? %>
+          <li><%= link_to 'Paper form', @service.paper_form_url %></li>
+        <% end %>
+      </ul>
+
+   </div>
   </div>
 
   <div class="grid-row">
-    <div class="column-full">
-      <h1 class="heading-large">
-        Data about the service
-      </h1>
+    <div class="column-two-thirds">
+      <h1 class="heading-large">Data about the service</h1>
       <ul class="list list-bullet">
         <li><%= render 'view_data/metrics/time_period_selector', time_period: @metrics.time_period %></li>
+        <li>This service is delivered by <a href=""><%= @service.delivery_organisation.name %></a></li>
       </ul>
-
-      <div class='m-metric-group'>
-        <div>
-          <div class='completeness service-context-completeness'>
-            <%= @metrics.metric_groups.last.completeness %> of data provided
-          </div>
-
-          <div class="m-metrics">
-            <div class="column-one-half" style="padding:0;">
-              <%= render @metrics.metric_groups.last.metrics[0], metric_group: @metrics.metric_groups.last %>
-              <%= render @metrics.metric_groups.last.metrics[2], metric_group: @metrics.metric_groups.last %>
-            </div>
-            <div class="column-one-half" style="padding:0;">
-              <%= render @metrics.metric_groups.last.metrics[1], metric_group: @metrics.metric_groups.last %>
-            </div>
-          </div>
-        </div>
-      </div>
     </div>
   </div>
+
+  <hr/>
+
+  <div class="grid-row">
+    <div class="column-two-thirds">
+      <h1 class="heading-large">Transactions received</h1>
+      <% if received_not_applicable?(@service) -%>
+        <p>This service doesn't receive transactions</p>
+      <% else -%>
+        <p>
+          These numbers tell you how much the organisation was used, and which channels were used the most.
+        </p>
+        <p>
+          <a href="">See a detailed description of how transactions received is defined.</a>
+        </p>
+      <% end %>
+    </div>
+  </div>
+
+  <hr/>
+
+  <div class="grid-row">
+    <div class="column-two-thirds">
+      <h1 class="heading-large">Transactions processed</h1>
+      <% if processed_not_applicable?(@service) -%>
+        <p>This service doesn't process transactions</p>
+      <% else -%>
+        <p>
+          These numbers tell you how many transactions were processed by the organisation, and how well these transactions met users' needs.
+        </p>
+        <p>
+          <a href="">See a detailed description of how transactions processed is defined.</a>
+        </p>
+      <% end %>
+    </div>
+  </div>
+
+  <hr/>
+
+  <div class="grid-row">
+    <div class="column-two-thirds">
+      <h1 class="heading-large">Phone calls received</h1>
+      <% if calls_not_applicable?(@service) -%>
+        <p>This service doesn't receive calls</p>
+      <% else -%>
+        <p>
+          These numbers tell you how much call centres were used, and why.
+        </p>
+        <p>
+          If the total number of calls is higher than the number of transactions, that’s an indication that effort is high compared to output.
+        </p>
+        <p>
+          If the proportion of users calling to chase progress is high, this might mean that the organisation isn’t processing transactions as quickly as they should. A high proportion of calls to get more information could indicate that information available online is incomplete or unclear.
+        </p>
+        <p>
+          <a href="">See a detailed description of how phone calls received is defined.</a>
+        </p>
+      <% end %>
+    </div>
+  </div>
+
 </main>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -7,6 +7,7 @@ en:
         paper: Paper transactions received
         face_to_face: Face to face transactions received
         other: Other transactions received
+        total: Total transactions received
       TransactionsProcessedMetric:
         total: Total transactions processed
         with_intended_outcome: Transactions ending in the user's intended outcome

--- a/spec/features/viewing_delivery_organisations_spec.rb
+++ b/spec/features/viewing_delivery_organisations_spec.rb
@@ -14,8 +14,8 @@ RSpec.feature 'viewing department detail pages', type: :feature do
 
     visit view_data_delivery_organisation_path(id: delivery_organisation.natural_key)
 
-    expect(page).to have_content('Department for Transport')
-    expect(page).to have_content('Detailed data for Highways England')
+    expect(page).to have_content('Detailed data')
+    expect(page).to have_content('Highways England')
     expect(page).to have_content('2 services')
   end
 end

--- a/spec/features/viewing_delivery_organisations_spec.rb
+++ b/spec/features/viewing_delivery_organisations_spec.rb
@@ -17,5 +17,6 @@ RSpec.feature 'viewing department detail pages', type: :feature do
     expect(page).to have_content('Detailed data')
     expect(page).to have_content('Highways England')
     expect(page).to have_content('2 services')
+    expect(page).to have_content('Change time period')
   end
 end

--- a/spec/features/viewing_departments_spec.rb
+++ b/spec/features/viewing_departments_spec.rb
@@ -17,5 +17,6 @@ RSpec.feature 'viewing department detail pages', type: :feature do
     expect(page).to have_content('Detailed data')
     expect(page).to have_content('Department for Transport')
     expect(page).to have_content('2 services')
+    expect(page).to have_content('Change time period')
   end
 end

--- a/spec/features/viewing_departments_spec.rb
+++ b/spec/features/viewing_departments_spec.rb
@@ -14,8 +14,8 @@ RSpec.feature 'viewing department detail pages', type: :feature do
 
     visit view_data_department_path(id: department.natural_key)
 
-    expect(page).to have_content('Detailed data for Department for Transport')
-    expect(page).to have_content('1 delivery organisation')
+    expect(page).to have_content('Detailed data')
+    expect(page).to have_content('Department for Transport')
     expect(page).to have_content('2 services')
   end
 end

--- a/spec/features/viewing_services_spec.rb
+++ b/spec/features/viewing_services_spec.rb
@@ -21,6 +21,7 @@ RSpec.feature 'viewing services', type: :feature do
 
     click_on 'Pay the Dartford Crossing charge (Dartcharge)'
     expect(page).to have_content('Pay the Dartford Crossing charge (Dartcharge)')
+    expect(page).to have_content('Change time period')
   end
 
   specify 'viewing a service with not-provided data' do

--- a/spec/features/viewing_services_spec.rb
+++ b/spec/features/viewing_services_spec.rb
@@ -20,8 +20,7 @@ RSpec.feature 'viewing services', type: :feature do
     expect(page).to have_content('Highways England')
 
     click_on 'Pay the Dartford Crossing charge (Dartcharge)'
-    expect(page).to have_content('Performance data about Pay the Dartford Crossing charge (Dartcharge)')
-    expect(page).to have_content('5.75m')
+    expect(page).to have_content('Pay the Dartford Crossing charge (Dartcharge)')
   end
 
   specify 'viewing a service with not-provided data' do
@@ -40,29 +39,6 @@ RSpec.feature 'viewing services', type: :feature do
     expect(page).to have_content('Planning Inspectorate')
 
     click_on 'National Infrastructure applications'
-    expect(page).to have_content('Not applicable')
     expect(page).to have_content("doesn't receive calls")
-  end
-
-  specify 'viewing a service with completeness info' do
-    department = FactoryGirl.create(:department, name: 'Department for Environment, Food & Rural Affairs')
-    delivery_organisation = FactoryGirl.create(:delivery_organisation, department: department, name: 'Environment Agency')
-    service = FactoryGirl.create(:service, :transactions_received_not_applicable, :calls_received_not_applicable, delivery_organisation: delivery_organisation, name: 'Flood Information Service')
-
-    month = time_period.start_month
-    6.times do
-      FactoryGirl.create(:monthly_service_metrics, :published, service: service, month: month, transactions_processed: 100, transactions_processed_with_intended_outcome: 100)
-      month = month.succ
-    end
-
-    visit view_data_government_metrics_path(group_by: Metrics::GroupBy::Department)
-
-    click_on 'Department for Environment, Food & Rural Affairs'
-    click_on 'Environment Agency'
-    click_on 'Flood Information Service'
-
-    expect(page).to have_content('50% of data provided')
-    expect(page).to have_content('Based on incomplete data')
-    expect(page).to have_content('Data provided for 6 of 12 months')
   end
 end


### PR DESCRIPTION
For the detail pages, simply duplicates the metrics presenter to fetch
the previous time-periods worth of data.  This will eventually be
pivoted to be grouped by metric so that it can be used in the charts.

Also creates a skeleton detail page for each entity type. For each 
entity, this PR creates a skeleton page, with content but not yet 
with any data shown, although the data is available to the page.

Currently this relies a lot on a helper to obtain the label for
different metrics (from the en.yml file) which are used elsewhere.  This
is pending a change to the data model where the labels, and a metric
iterator will be made available directly, and metric names used 
consistently between the model and the UI.
