### PR TITLE
Add the gds_metrics gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -37,6 +37,7 @@ gem 'paper_trail'
 # Logging
 gem 'lograge'
 gem 'logstash-event'
+gem 'gds_metrics'
 
 group :development, :test do
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -125,6 +125,8 @@ GEM
     formtastic (3.1.5)
       actionpack (>= 3.2.13)
     formtastic_i18n (0.6.0)
+    gds_metrics (0.0.1)
+      prometheus-client-mmap (= 0.9.1)
     globalid (0.4.0)
       activesupport (>= 4.2.0)
     govuk-lint (3.2.0)
@@ -209,6 +211,7 @@ GEM
     polyamorous (1.3.1)
       activerecord (>= 3.0)
     powerpack (0.1.1)
+    prometheus-client-mmap (0.9.1)
     public_suffix (3.0.0)
     puma (3.8.2)
     rack (2.0.3)
@@ -357,6 +360,7 @@ DEPENDENCIES
   factory_girl_rails
   faraday
   faraday_middleware
+  gds_metrics
   govuk-lint
   govuk_elements_rails
   govuk_frontend_toolkit (~> 7.2)

--- a/manifest.yml
+++ b/manifest.yml
@@ -7,3 +7,5 @@ applications:
       - cgsd-pg-service
       - logit-ssl-drain-sp
       - service-performance-staging-credentials
+    env:
+      PROMETHEUS_METRICS_PATH: /metrics


### PR DESCRIPTION
Adds the prometheus/gds metrics gem and tells the manifest to mount the metrics at /metrics.