### PR TITLE
Fix how c3.css is loaded

### DIFF
--- a/app/assets/stylesheets/__base.scss
+++ b/app/assets/stylesheets/__base.scss
@@ -1,5 +1,3 @@
-@import "c3.css";
-
 @import "_grid_layout.scss";
 @import "_conditionals.scss";
 @import "_colours.scss";

--- a/app/views/layouts/view_data.html.erb
+++ b/app/views/layouts/view_data.html.erb
@@ -14,6 +14,7 @@
 
     <!--[if gt IE 8]><!--><%= stylesheet_link_tag :screen, media: 'screen' %><!--<![endif]-->
     <!--[if lte IE 8]><%= stylesheet_link_tag 'screen-old-ie', media: 'screen' %><![endif]-->
+    <%= stylesheet_link_tag :c3, media: 'screen' %>
     <%= stylesheet_link_tag :print, media: 'print' %>
 
     <!--[if IE 8]><%= stylesheet_link_tag 'fonts-ie8', media: :all %><![endif]-->

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -12,5 +12,6 @@ Rails.application.config.assets.precompile = [
   'govuk_template/source/assets/javascripts/vendor/html5shiv-printshiv.js',
   'govuk_template/source/assets/images/gov.uk_logotype_crown_invert_trans.png',
   'admin/admin.css',
-  'view_data.js'
+  'view_data.js',
+  'c3.css'
 ]


### PR DESCRIPTION
Loads the c3.css explicitly. Once we have a new layout for pages that have charts, we can move it there and hopefully shrink the precompiled assets a little.