### PR TITLE
Adds a helper to the service model for applicability

### DIFF
--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -18,6 +18,10 @@ class Service < ApplicationRecord
     self.joins(:metrics).where(monthly_service_metrics: { published: true }).distinct
   end
 
+  def metric_applicable?(metric_name)
+    self.send("#{metric_name}_applicable".to_sym)
+  end
+
   def required_metrics
     %i[online_transactions_applicable
        phone_transactions_applicable

--- a/spec/models/service_spec.rb
+++ b/spec/models/service_spec.rb
@@ -17,6 +17,18 @@ RSpec.describe Service, type: :model do
     end
   end
 
+  it 'can determine if metrics are not applicable' do
+    service = FactoryGirl.build(:service)
+    applicable = service.metric_applicable?(:online_transactions)
+    expect(applicable).to eq(true)
+  end
+
+  it 'can determine if metrics are applicable' do
+    service = FactoryGirl.build(:service, online_transactions_applicable: false)
+    applicable = service.metric_applicable?(:online_transactions)
+    expect(applicable).to eq(false)
+  end
+
   it 'generates a publish token, when created' do
     service = FactoryGirl.build(:service)
     expect {


### PR DESCRIPTION
To simplify checking whether a metric within a service is applicable or
not, this PR provides a helper method on the service object.  When
passed the metric symbol (e.g. online_transactions) it will return true
or false depending on the appropriate flag in the service model.