### PR TITLE
Initial layout of charts for depts, deliveryorgs and services.

### DIFF
--- a/app/assets/javascripts/view_data.js
+++ b/app/assets/javascripts/view_data.js
@@ -5,6 +5,8 @@
 // = require d3
 // = require c3
 
+/*global d3*/
+
 ;(function (global) {
   /* Both of these are in the `search.js` file */
 
@@ -57,7 +59,8 @@
         y: {
           min: 0,
           max: maxValue,
-          padding: { top: 0, bottom: 0 }
+          padding: { top: 0, bottom: 0 },
+          tick: { format: function (x) { return d3.format(',.0f')(x) } }
         }
       }
 
@@ -70,10 +73,17 @@
         bindto: '#' + $(obj).attr('id'),
         data: {
           columns: [
-            currentData,
-            previousData
+            previousData,
+            currentData
           ],
           regions: cRegions
+        },
+        tooltip: {
+          format: {
+              value: function(value) {
+                  return d3.format(',.0f')(value) + '&nbsp;&nbsp;&nbsp;'
+              }
+          }
         },
         axis: setAxisTransactions, size: cSize, color: cColour, transition: cTransition, padding: cPadding, point: cPoint
       });

--- a/app/assets/stylesheets/__base.scss
+++ b/app/assets/stylesheets/__base.scss
@@ -55,6 +55,10 @@ fieldset > h2 {
     margin-top: 20px;
 }
 
+.top-space {
+    margin-top: 60px;
+}
+
 @import "breadcrumbs";
 @import "homepage";
 @import "metadata";

--- a/app/assets/stylesheets/c3.css
+++ b/app/assets/stylesheets/c3.css
@@ -48,7 +48,7 @@
 
 /*-- Line --*/
 .c3-line {
-  stroke-width: 1px; }
+  stroke-width: 2px; }
 
 /*-- Point --*/
 .c3-circle._expanded_ {

--- a/app/controllers/view_data/services_controller.rb
+++ b/app/controllers/view_data/services_controller.rb
@@ -6,6 +6,9 @@ module ViewData
       @metrics = MetricsPresenter.new(@service, group_by: Metrics::GroupBy::Service, time_period: time_period)
       @previous = MetricsPresenter.new(@service, group_by: Metrics::GroupBy::Service, time_period: time_period.previous_period)
 
+      @current_by_metrics = @metrics.metric_groups.last.sorted_metrics_by_month
+      @previous_by_metrics = @previous.metric_groups.last.sorted_metrics_by_month
+
       page.title = @service.name
       page.breadcrumbs << Page::Crumb.new('UK Government', view_data_government_metrics_path)
       page.breadcrumbs << Page::Crumb.new(@service.department.name, view_data_department_metrics_path(department_id: @service.department))

--- a/app/helpers/services_helper.rb
+++ b/app/helpers/services_helper.rb
@@ -5,4 +5,43 @@ module ServicesHelper
     markdown = Redcarpet::Markdown.new(Redcarpet::Render::HTML, autolink: true)
     markdown.render(field).html_safe
   end
+
+  def transactions_received_applicable_list(service)
+    [
+      %i(total_transactions total),
+      %i(online_transactions online),
+      %i(phone_transactions phone),
+      %i(paper_transactions paper),
+      %i(face_to_face_transactions face_to_face),
+      %i(other_transactions other)
+    ].select do |long, short|
+      if short == :total
+        true
+      else
+        service.metric_applicable?(long)
+      end
+    end
+  end
+
+  def transactions_processed_applicable_list(service)
+    [
+      %i(transactions_processed total),
+      %i(transactions_processed_with_intended_outcome with_intended_outcome)
+    ].select do |long, _short|
+      service.metric_applicable?(long)
+    end
+  end
+
+  def calls_received_applicable_list(service)
+    [
+      %i(calls_received total),
+      %i(calls_received_perform_transaction perform_transaction),
+      %i(calls_received_get_information get_information),
+      %i(calls_received_chase_progress chase_progress),
+      %i(calls_received_challenge_decision challenge_a_decision),
+      %i(calls_received_other other)
+    ].select do |long, _short|
+      service.metric_applicable?(long)
+    end
+  end
 end

--- a/app/models/time_period.rb
+++ b/app/models/time_period.rb
@@ -50,6 +50,12 @@ class TimePeriod
     start_month..end_month
   end
 
+  def months_as_short_names
+    months.to_a.map { |m|
+      m.starts_on.to_formatted_s(:month)
+    }
+  end
+
   attr_reader :starts_on, :ends_on
 
   def start_month
@@ -58,6 +64,10 @@ class TimePeriod
 
   def end_month
     YearMonth.new(ends_on.year, ends_on.month)
+  end
+
+  def range_label
+    "#{start_month.to_formatted_s(:month_and_year)} to #{end_month.to_formatted_s(:month_and_year)}"
   end
 
   # Obtain the number of months that this date range covers.

--- a/app/views/view_data/charts/_metric_chart.html.erb
+++ b/app/views/view_data/charts/_metric_chart.html.erb
@@ -1,0 +1,20 @@
+<div class="grid-row top-space">
+  <div class="column-one-third">
+    <div class="data">
+      <span class="data-item bold-xxlarge"><%= metric_to_human(current_metrics.sum) %></span>
+      <span class="data-item bold-xsmall"><%= total_label %></span>
+    </div>
+  </div>
+
+  <div class="column-two-thirds">
+    <%= render 'view_data/charts/chart',
+          id: metric.to_s,
+          current_range_label: time_period.range_label,
+          previous_range_label: time_period.previous_period.range_label,
+          months: time_period.months_as_short_names,
+          current_data: current_metrics,
+          previous_data: previous_metrics,
+          max_value: (current_metrics + previous_metrics).max,
+          label: "#{total_label} by #{organisation}, #{time_period.range_label}" %>
+  </div>
+</div>

--- a/app/views/view_data/delivery_organisations/show.html.erb
+++ b/app/views/view_data/delivery_organisations/show.html.erb
@@ -33,14 +33,62 @@
     </div>
   </div>
 
+
   <%= render partial: "view_data/transactions_received_section" %>
+
+  <% [[:total_transactions,        :total],
+      [:online_transactions,       :online],
+      [:phone_transactions,        :phone],
+      [:paper_transactions,        :paper],
+      [:face_to_face_transactions, :face_to_face],
+      [:other_transactions,        :other]
+     ].each do |metric_name, short_metric_name| %>
+    <%= render partial: "view_data/charts/metric_chart", locals: {
+          metric: metric_name,
+          time_period: @metrics.time_period,
+          current_metrics: @current_by_metrics[metric_name],
+          previous_metrics: @previous_by_metrics[metric_name],
+          total_label: trxn_rx_metric_label(short_metric_name),
+          organisation: @delivery_organisation.name
+    } %>
+  <% end %>
 
   <hr/>
 
   <%= render partial: "view_data/transactions_processed_section" %>
 
+  <% [[:transactions_processed,     :total],
+      [:transactions_processed_with_intended_outcome, :with_intended_outcome]
+     ].each do |metric_name, short_metric_name| %>
+    <%= render partial: "view_data/charts/metric_chart", locals: {
+          metric: metric_name,
+          time_period: @metrics.time_period,
+          current_metrics: @current_by_metrics[metric_name],
+          previous_metrics: @previous_by_metrics[metric_name],
+          total_label: trxn_proc_metric_label(short_metric_name),
+          organisation: @delivery_organisation.name
+    } %>
+  <% end %>
+
   <hr/>
 
   <%= render partial: "view_data/calls_received_section" %>
+
+  <% [[:calls_received,                     :total],
+      [:calls_received_perform_transaction, :perform_transaction],
+      [:calls_received_get_information,     :get_information],
+      [:calls_received_chase_progress,      :chase_progress],
+      [:calls_received_challenge_decision,  :challenge_a_decision],
+      [:calls_received_other,               :other],
+     ].each do |metric_name, short_metric_name| %>
+    <%= render partial: "view_data/charts/metric_chart", locals: {
+          metric: metric_name,
+          time_period: @metrics.time_period,
+          current_metrics: @current_by_metrics[metric_name],
+          previous_metrics: @previous_by_metrics[metric_name],
+          total_label: calls_metric_label(short_metric_name),
+          organisation: @delivery_organisation.name
+    } %>
+  <% end %>
 
 </main>

--- a/app/views/view_data/departments/show.html.erb
+++ b/app/views/view_data/departments/show.html.erb
@@ -35,12 +35,59 @@
 
   <%= render partial: "view_data/transactions_received_section" %>
 
+  <% [[:total_transactions,        :total],
+      [:online_transactions,       :online],
+      [:phone_transactions,        :phone],
+      [:paper_transactions,        :paper],
+      [:face_to_face_transactions, :face_to_face],
+      [:other_transactions,        :other]
+     ].each do |metric_name, short_metric_name| %>
+    <%= render partial: "view_data/charts/metric_chart", locals: {
+          metric: metric_name,
+          time_period: @metrics.time_period,
+          current_metrics: @current_by_metrics[metric_name],
+          previous_metrics: @previous_by_metrics[metric_name],
+          total_label: trxn_rx_metric_label(short_metric_name),
+          organisation: @department.name
+    } %>
+  <% end %>
+
   <hr/>
 
   <%= render partial: "view_data/transactions_processed_section" %>
 
+  <% [[:transactions_processed,     :total],
+      [:transactions_processed_with_intended_outcome, :with_intended_outcome]
+     ].each do |metric_name, short_metric_name| %>
+    <%= render partial: "view_data/charts/metric_chart", locals: {
+          metric: metric_name,
+          time_period: @metrics.time_period,
+          current_metrics: @current_by_metrics[metric_name],
+          previous_metrics: @previous_by_metrics[metric_name],
+          total_label: trxn_proc_metric_label(short_metric_name),
+          organisation: @department.name
+    } %>
+  <% end %>
+
   <hr/>
 
   <%= render partial: "view_data/calls_received_section" %>
+
+  <% [[:calls_received,                     :total],
+      [:calls_received_perform_transaction, :perform_transaction],
+      [:calls_received_get_information,     :get_information],
+      [:calls_received_chase_progress,      :chase_progress],
+      [:calls_received_challenge_decision,  :challenge_a_decision],
+      [:calls_received_other,               :other],
+     ].each do |metric_name, short_metric_name| %>
+    <%= render partial: "view_data/charts/metric_chart", locals: {
+          metric: metric_name,
+          time_period: @metrics.time_period,
+          current_metrics: @current_by_metrics[metric_name],
+          previous_metrics: @previous_by_metrics[metric_name],
+          total_label: calls_metric_label(short_metric_name),
+          organisation: @department.name
+    } %>
+  <% end %>
 
 </main>

--- a/app/views/view_data/services/show.html.erb
+++ b/app/views/view_data/services/show.html.erb
@@ -76,7 +76,7 @@
   <hr/>
 
   <div class="grid-row">
-    <div class="column-two-thirds">
+    <div class="column-full">
       <h1 class="heading-large">Transactions received</h1>
       <% if received_not_applicable?(@service) -%>
         <p>This service doesn't receive transactions</p>
@@ -87,6 +87,18 @@
         <p>
           <a href="">See a detailed description of how transactions received is defined.</a>
         </p>
+
+        <% transactions_received_applicable_list(@service).each do |metric_name, short_metric_name| %>
+          <%= render partial: "view_data/charts/metric_chart", locals: {
+                metric: metric_name,
+                time_period: @metrics.time_period,
+                current_metrics: @current_by_metrics[metric_name],
+                previous_metrics: @previous_by_metrics[metric_name],
+                total_label: trxn_rx_metric_label(short_metric_name),
+                organisation: @service.name
+          } %>
+        <% end %>
+
       <% end %>
     </div>
   </div>
@@ -94,7 +106,7 @@
   <hr/>
 
   <div class="grid-row">
-    <div class="column-two-thirds">
+    <div class="column-full">
       <h1 class="heading-large">Transactions processed</h1>
       <% if processed_not_applicable?(@service) -%>
         <p>This service doesn't process transactions</p>
@@ -105,6 +117,18 @@
         <p>
           <a href="">See a detailed description of how transactions processed is defined.</a>
         </p>
+
+        <% transactions_processed_applicable_list(@service).each do |metric_name, short_metric_name| %>
+            <%= render partial: "view_data/charts/metric_chart", locals: {
+                  metric: metric_name,
+                  time_period: @metrics.time_period,
+                  current_metrics: @current_by_metrics[metric_name],
+                  previous_metrics: @previous_by_metrics[metric_name],
+                  total_label: trxn_proc_metric_label(short_metric_name),
+                  organisation: @service.name
+            } %>
+          <% end %>
+
       <% end %>
     </div>
   </div>
@@ -112,7 +136,7 @@
   <hr/>
 
   <div class="grid-row">
-    <div class="column-two-thirds">
+    <div class="column-full">
       <h1 class="heading-large">Phone calls received</h1>
       <% if calls_not_applicable?(@service) -%>
         <p>This service doesn't receive calls</p>
@@ -129,6 +153,18 @@
         <p>
           <a href="">See a detailed description of how phone calls received is defined.</a>
         </p>
+
+        <% calls_received_applicable_list(@service).each do |metric_name, short_metric_name| %>
+        <%= render partial: "view_data/charts/metric_chart", locals: {
+              metric: metric_name,
+              time_period: @metrics.time_period,
+              current_metrics: @current_by_metrics[metric_name],
+              previous_metrics: @previous_by_metrics[metric_name],
+              total_label: calls_metric_label(short_metric_name),
+              organisation: @service.name
+        } %>
+        <% end %>
+
       <% end %>
     </div>
   </div>

--- a/config/initializers/date_formats.rb
+++ b/config/initializers/date_formats.rb
@@ -6,3 +6,4 @@ Date::DATE_FORMATS[:long_month_year] = '%B %Y'
 Date::DATE_FORMATS[:long_day_month] = '%-d %B'
 Date::DATE_FORMATS[:abbreviated_day_month_year] = "%-d %b %Y"
 Date::DATE_FORMATS[:month_and_year] = '%B %Y'
+Date::DATE_FORMATS[:month] = '%b'


### PR DESCRIPTION
Displays the charts for the department page, the delivery organisation
page and the services page.  The charts currently have several issues:

* The legend does not match the styles used for lines (one solid blue
and one dashed blue)

* Not Provided is not shown when data is not provided, we don't really
know at the point of use at the moment.

* It doesn't follow the guidelines at https://sp-trends.herokuapp.com/charts

This still requires the percentage change when there is a previous time
period (not all data has this yet).