### PR TITLE
Adds a chart page for Government

### DIFF
--- a/app/controllers/view_data/government_controller.rb
+++ b/app/controllers/view_data/government_controller.rb
@@ -8,5 +8,23 @@ module ViewData
       calc = MissingDataCalculator.new(@government, @time_period)
       @missing_data = calc.missing_data
     end
+
+    def show
+      @government = Government.new
+      @time_period = time_period
+
+      @metrics = MetricsPresenter.new(@government, group_by: Metrics::GroupBy::Service, time_period: time_period)
+      @previous = MetricsPresenter.new(@government, group_by: Metrics::GroupBy::Service, time_period: time_period.previous_period)
+
+      @current_by_metrics = @metrics.metric_groups.first.sorted_metrics_by_month
+      @previous_by_metrics = @previous.metric_groups.first.sorted_metrics_by_month
+
+      page.title = @government.name
+
+      respond_to do |format|
+        format.html
+        format.csv { render csv: MetricsCSVExporter.new(@metrics.published_monthly_service_metrics) }
+      end
+    end
   end
 end

--- a/app/views/view_data/government/show.html.erb
+++ b/app/views/view_data/government/show.html.erb
@@ -1,0 +1,93 @@
+<main id="content" role="main">
+
+  <a class="link-back" href="<%= view_data_government_metrics_path %>">Back to UK Government</a>
+
+  <div class="grid-row">
+    <div class="column-two-thirds">
+      <h1 class="heading-xlarge small-top-margin">
+        <span class="prefix">Detailed data for</span>
+        <%= @government.name %>
+      </h1>
+    </div>
+
+    <aside class="column-one-third download">
+      <div class="notice">
+        <i class="icon icon-file-download">
+          <span class="visuallyhidden">Download file</span>
+        </i>
+        <strong class="xbold-small"><%= link_to 'Download data for this page (CSV)', url_for(request.params.merge(format: :csv)) %></strong>
+      </div>
+    </aside>
+  </div>
+
+  <div class="grid-row">
+    <div class="column-two-thirds detail-context">
+      <ul class="list list-bullet">
+        <li>
+          <%= render 'view_data/metrics/time_period_selector', time_period: @metrics.time_period %>
+        </li>
+        <li>
+          This data is aggregated from <a href="<%= view_data_government_metrics_path group_by: Metrics::GroupBy::Service %>"><%= pluralize(@government.services_count, 'service')%></a>
+        </li>
+      </ul>
+    </div>
+  </div>
+
+  <%= render partial: "view_data/transactions_received_section" %>
+
+  <% [[:total_transactions,        :total],
+      [:online_transactions,       :online],
+      [:phone_transactions,        :phone],
+      [:paper_transactions,        :paper],
+      [:face_to_face_transactions, :face_to_face],
+      [:other_transactions,        :other]
+     ].each do |metric_name, short_metric_name| %>
+    <%= render partial: "view_data/charts/metric_chart", locals: {
+          metric: metric_name,
+          time_period: @metrics.time_period,
+          current_metrics: @current_by_metrics[metric_name],
+          previous_metrics: @previous_by_metrics[metric_name],
+          total_label: trxn_rx_metric_label(short_metric_name),
+          organisation: @government.name
+    } %>
+  <% end %>
+
+  <hr/>
+
+  <%= render partial: "view_data/transactions_processed_section" %>
+
+  <% [[:transactions_processed,     :total],
+      [:transactions_processed_with_intended_outcome, :with_intended_outcome]
+     ].each do |metric_name, short_metric_name| %>
+    <%= render partial: "view_data/charts/metric_chart", locals: {
+          metric: metric_name,
+          time_period: @metrics.time_period,
+          current_metrics: @current_by_metrics[metric_name],
+          previous_metrics: @previous_by_metrics[metric_name],
+          total_label: trxn_proc_metric_label(short_metric_name),
+          organisation: @government.name
+    } %>
+  <% end %>
+
+  <hr/>
+
+  <%= render partial: "view_data/calls_received_section" %>
+
+  <% [[:calls_received,                     :total],
+      [:calls_received_perform_transaction, :perform_transaction],
+      [:calls_received_get_information,     :get_information],
+      [:calls_received_chase_progress,      :chase_progress],
+      [:calls_received_challenge_decision,  :challenge_a_decision],
+      [:calls_received_other,               :other],
+     ].each do |metric_name, short_metric_name| %>
+    <%= render partial: "view_data/charts/metric_chart", locals: {
+          metric: metric_name,
+          time_period: @metrics.time_period,
+          current_metrics: @current_by_metrics[metric_name],
+          previous_metrics: @previous_by_metrics[metric_name],
+          total_label: calls_metric_label(short_metric_name),
+          organisation: @government.name
+    } %>
+  <% end %>
+
+</main>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -37,6 +37,7 @@ Rails.application.routes.draw do
           defaults: { group_by: Metrics::GroupBy::Department },
           as: :government_metrics
         get 'missing', to: 'view_data/government#missing'
+        get '', to: 'view_data/government#show'
       end
 
       resources :departments, only: [] do


### PR DESCRIPTION
Adds a new route to /performance-data/government which shows the charts
for all of the services we have so far.  This is to be linked to from
the totals box on /performance-data/government/metrics/department