### PR TITLE
Add user's name to User model and import/assign to services

### DIFF
--- a/app/admin/service.rb
+++ b/app/admin/service.rb
@@ -21,9 +21,7 @@ ActiveAdmin.register Service do
     attributes_table do
       row :name
       row :delivery_organisation
-      row "Owner" do |service|
-        service.owner.email if service.owner
-      end
+      row("Owner", &:owner)
       row :natural_key
       row :created_at
       row :updated_at

--- a/app/admin/user.rb
+++ b/app/admin/user.rb
@@ -1,9 +1,10 @@
 ActiveAdmin.register User do
-  permit_params :email, :password, :password_confirmation
+  permit_params :first_name, :last_name, :email, :password, :password_confirmation
 
   index do
     selectable_column
     id_column
+    column("Name", &:full_name)
     column :email
     column :current_sign_in_at
     column :sign_in_count
@@ -13,6 +14,7 @@ ActiveAdmin.register User do
 
   show do
     attributes_table do
+      row("Name", &:full_name)
       row :email
       row :current_sign_in_at
       row :sign_in_count
@@ -37,6 +39,8 @@ ActiveAdmin.register User do
     passwd = Devise.friendly_token.first(32)
 
     f.inputs do
+      f.input :first_name
+      f.input :last_name
       f.input :email
       f.input :password, input_html: { value: f.object.password ||= passwd }
       f.input :password_confirmation, input_html: { value: f.object.password_confirmation ||= passwd }

--- a/app/models/service.rb
+++ b/app/models/service.rb
@@ -48,4 +48,8 @@ class Service < ApplicationRecord
   def missing_data_link
     Rails.application.routes.url_helpers.view_data_service_url(self, only_path: true)
   end
+
+  def to_s
+    name
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -6,6 +6,10 @@ class User < ApplicationRecord
 
   has_many :services, foreign_key: :owner_id
 
+  def full_name
+    "#{first_name} #{last_name}"
+  end
+
   def to_s
     email
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -11,6 +11,6 @@ class User < ApplicationRecord
   end
 
   def to_s
-    email
+    "#{full_name} <#{email}>"
   end
 end

--- a/app/views/admin/services/generate_magic_links.html.erb
+++ b/app/views/admin/services/generate_magic_links.html.erb
@@ -17,7 +17,7 @@
     <tr>
       <td><%= date.year %></td>
       <td><%= date.strftime("%B") %></td>
-      <td><%= service.owner.email if service.owner %></td>
+      <td><%= "#{service.owner.full_name } <#{service.owner.email}>" if service.owner %></td>
       <td>
         <%= publish_service_metrics_url(
                                   service_id: service.id,

--- a/db/migrate/20180308150755_add_name_to_user.rb
+++ b/db/migrate/20180308150755_add_name_to_user.rb
@@ -1,0 +1,6 @@
+class AddNameToUser < ActiveRecord::Migration[5.1]
+  def change
+    add_column :users, :first_name, :string
+    add_column :users, :last_name, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180123133950) do
+ActiveRecord::Schema.define(version: 20180308150755) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -139,6 +139,8 @@ ActiveRecord::Schema.define(version: 20180123133950) do
     t.datetime "locked_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "first_name"
+    t.string "last_name"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end

--- a/lib/tasks/users_import.rake
+++ b/lib/tasks/users_import.rake
@@ -1,0 +1,37 @@
+# Imports users from a CSV file
+#
+# Run with:
+#     rake users_import:load < users.csv
+#
+# Where the first column is the user's name, the second their email
+# and the third is the name of the service
+require 'csv'
+
+namespace :users_import do
+  desc "Import users from a CSV and assign to a service"
+  task load: :environment do
+    CSV($stdin, row_sep: "\r\n").each do |row|
+      name = row[0]
+      email = row[1].downcase.strip
+      service_name = row[2]
+      parsed_name = name.split(' ')
+
+      user = User.where(email: email).first || User.create
+      user.email = email
+      user.password = Devise.friendly_token.first(32)
+      user.first_name = parsed_name[0]
+      user.last_name = parsed_name[1]
+      user.save!
+
+      service = Service.where(name: service_name).first
+      if service.nil?
+        puts "! Failed to find service #{service_name}. User created but not assigned."
+        next
+      end
+      service.owner = user
+      service.save!
+
+      puts "Added #{user} to #{service}"
+    end
+  end
+end


### PR DESCRIPTION
We use the User model to specify an owner for the service, so that we
know who to email. This PR adds a first_name and last_name field to the
model so we can address them correctly in the email.

In order to allow services to have 'owners' this PR contains a rake task
that will import users from a CSV file.  The CSV file must have 3
columns, the first containing the user's name, the second their email
address and the final column the name of the Service.  The last column
must (unfortunately) exactly match the entry in the database.

The rake task should be run using:

    rake users_import:load < users.csv

Piping the csv into stdin will allow us to pipe it across a tunnel to a
running instance.